### PR TITLE
Configured eos-metrics-instrumentation as a Daemon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ stamp*
 Makefile
 Makefile.in
 gtk-doc.make
+data/eos-metrics-instrumentation.service
 /aclocal.m4
 /autom4te.cache
 /compile

--- a/Makefile.am
+++ b/Makefile.am
@@ -28,3 +28,6 @@ DISTCLEANFILES =
 
 # Instrumentation
 include $(top_srcdir)/src/Makefile.am.inc
+
+# Daemon Configuration
+include $(top_srcdir)/data/Makefile.am.inc

--- a/configure.ac
+++ b/configure.ac
@@ -74,6 +74,8 @@ AC_PROG_MKDIR_P
 AC_PROG_CC
 # Make sure the C compiler supports per-target CFLAGS
 AM_PROG_CC_C_O
+# Intializes PKG_CONFIG variable so that systemdsystemunitdir can be found.
+PKG_PROG_PKG_CONFIG
 
 AC_CACHE_SAVE
 
@@ -119,6 +121,9 @@ AS_CASE([$enable_strict_flags],
 dnl Strip leading spaces
 STRICT_CFLAGS=${STRICT_CFLAGS#*  }
 AC_SUBST(STRICT_CFLAGS)
+
+systemdsystemunitdir="$($PKG_CONFIG systemd --variable=systemdsystemunitdir)"
+AC_SUBST(systemdsystemunitdir)
 
 # Required libraries
 # ------------------

--- a/data/Makefile.am.inc
+++ b/data/Makefile.am.inc
@@ -1,0 +1,16 @@
+# Defined as systemdsystemunitdir in ../configure.ac.
+systemdsystemunit_DATA = data/eos-metrics-instrumentation.service
+
+data/eos-metrics-instrumentation.service: data/eos-metrics-instrumentation.service.in
+	$(AM_V_GEN)mkdir -p data && \
+	rm -f $@ $@.tmp && \
+	$(edit) $< >$@.tmp && \
+	mv $@.tmp $@
+
+edit = sed \
+	-e 's|@libexecdir[@]|$(libexecdir)|g' \
+	$(NULL)
+
+EXTRA_DIST += data/eos-metrics-instrumentation.service.in
+
+CLEANFILES += data/eos-metrics-instrumentation.service

--- a/data/eos-metrics-instrumentation.service.in
+++ b/data/eos-metrics-instrumentation.service.in
@@ -1,0 +1,12 @@
+[Unit]
+Description=EndlessOS Metrics Instrumentation
+Requires=dbus.service
+After=dbus.service
+Before=dbus-org.freedesktop.login1.service systemd-logind.service
+
+[Service]
+Type=simple
+ExecStart=@libexecdir@/eos-metrics-instrumentation
+
+[Install]
+WantedBy=sysinit.target


### PR DESCRIPTION
The daemon runs at startup once installed, and wakes up early enough to capture all the metrics we will want to collect. It sometimes dies too early to capture all the metrics we will want to collect (e.g., logout), so shutdown should be inhibited.

[endlessm/eos-sdk#761]
