### PR TITLE
Added missing build-time dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 eos-metrics-instrumentation
+data/
 *.o
 
 # Backup files
@@ -21,3 +22,8 @@ gtk-doc.make
 /depcomp
 /install-sh
 /missing
+
+# debuild Droppings
+*.after
+*.before
+*.log

--- a/debian/control
+++ b/debian/control
@@ -4,6 +4,7 @@ Priority: standard
 Maintainer: Kurt von Laven <kurt@endlessm.com>
 Build-Depends: debhelper (>= 9),
 	autotools-dev,
+	eos-metrics-0-dev,
 	libglib2.0-dev,
 	dh-autoreconf,
 	dh-systemd


### PR DESCRIPTION
The Jenkins build is currently failing saying the eosmetrics-0 dependency can't be found. I expect this change to fix the build failure.

[endlessm/eos-sdk#856]
