### PR TITLE
Respect DESTDIR and prefix in systemdsystemunitdir

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -15,9 +15,11 @@ EXTRA_DIST = README.md
 # Compiler flags
 AM_CFLAGS = @STRICT_CFLAGS@
 
-# Make sure to use strict compiler flags when doing 'make distcheck'
+# Make sure to use strict compiler flags when doing 'make distcheck', and
+# trick Automake into not installing something outside of $(prefix)
 AM_DISTCHECK_CONFIGURE_FLAGS = \
         --enable-strict-flags \
+        --with-systemdsystemunitdir='$${libdir}/systemd/system' \
         $(NULL)
 
 # Generated files that 'make clean' should erase

--- a/configure.ac
+++ b/configure.ac
@@ -124,7 +124,12 @@ STRICT_CFLAGS=${STRICT_CFLAGS#*  }
 AC_SUBST(STRICT_CFLAGS)
 
 systemdsystemunitdir="$($PKG_CONFIG systemd --variable=systemdsystemunitdir)"
-AC_SUBST(systemdsystemunitdir)
+dnl Allow overriding systemdsystemunitdir during distcheck in order to trick
+dnl Automake into allowing an install outside of $prefix
+AC_ARG_WITH([systemdsystemunitdir],
+    [AS_HELP_STRING([--with-systemdsystemunitdir=PATH], [directory for systemd service files])],
+    [systemdsystemunitdir="$withval"])
+AC_SUBST([systemdsystemunitdir])
 
 # Required libraries
 # ------------------


### PR DESCRIPTION
In order to pass distcheck, the systemd service file can't be installed
outside of $prefix -- Automake doesn't like that, but it previously
passed distcheck if $prefix was writable -- so for distcheck, you have
to have --with-systemdsystemunitdir=distcheck in the distcheck
configure flags.

In order to package the files properly in the Debian package, the
systemd directory also has to respect $DESTDIR, so we don't set the
systemdsystemunitdir variable directly in configure.ac anymore -- since
$DESTDIR is only known at build time.

[endlessm/eos-sdk#853]
