### PR TITLE
Fixed event type name.

### DIFF
--- a/src/eos-metrics-instrumentation.c
+++ b/src/eos-metrics-instrumentation.c
@@ -181,7 +181,7 @@ record_login (GDBusProxy *dbus_proxy,
         maybe_inhibit_shutdown (dbus_proxy);
         GVariant *session_id = g_variant_get_child_value (parameters, 0);
         emtr_event_recorder_record_start (event_recorder,
-                                          EMTR_EVENT_USER_LOGGED_IN, session_id,
+                                          EMTR_EVENT_USER_IS_LOGGED_IN, session_id,
                                           NULL /* auxiliary_payload */);
         g_variant_unref (session_id);
       }
@@ -190,7 +190,7 @@ record_login (GDBusProxy *dbus_proxy,
       {
         GVariant *session_id = g_variant_get_child_value (parameters, 0);
         emtr_event_recorder_record_stop (event_recorder,
-                                         EMTR_EVENT_USER_LOGGED_IN, session_id,
+                                         EMTR_EVENT_USER_IS_LOGGED_IN, session_id,
                                          NULL /* auxiliary_payload */);
         g_variant_unref (session_id);
         stop_inhibiting_shutdown ();


### PR DESCRIPTION
EMTR_EVENT_USER_LOGGED_IN

was changed to

EMTR_EVENT_USER_IS_LOGGED_IN.
[endlessm/eos-sdk#987]
