### PR TITLE
Assume all sessions removed on PrepareForShutdown.

### DIFF
--- a/data/eos-metrics-instrumentation.service.in
+++ b/data/eos-metrics-instrumentation.service.in
@@ -2,7 +2,7 @@
 Description=EndlessOS Metrics Instrumentation
 Requires=dbus.service
 After=dbus.service
-Before=dbus-org.freedesktop.login1.service systemd-logind.service
+Before=dbus-org.freedesktop.login1.service systemd-logind.service systemd-user-sessions.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
SessionRemoved is not sent in time if the user shuts down without
explicitly logging out and waiting ~15 seconds first. As a stop-gap,
make the aggressive assumption that all sessions are removed when the
PrepareForShutdown signal is sent. This assumption does not hold when
the shutdown is cancelled, but presumably that is a much less common
event than the user shutting down without explicitly logging out.

[endlessm/eos-shell#2216]
