### PR TITLE
Fix double unref.

### DIFF
--- a/src/eos-metrics-instrumentation.c
+++ b/src/eos-metrics-instrumentation.c
@@ -144,7 +144,6 @@ record_stop_for_login (GQuark   session_id_quark,
                                      EMTR_EVENT_USER_IS_LOGGED_IN,
                                      session_id_variant,
                                      NULL /* auxiliary_payload */);
-    g_variant_unref (session_id_variant);
 }
 
 /*


### PR DESCRIPTION
We shouldn't be unreffing a floating reference that we didn't ref sink
after handing it off to the event recorder. The event recorder is
responsible for releasing any floating references it is given.

[endlessm/eos-sdk#1692]
