### PR TITLE
Remove double-unref of network status change.

### DIFF
--- a/src/eos-metrics-instrumentation.c
+++ b/src/eos-metrics-instrumentation.c
@@ -442,7 +442,6 @@ record_network_change (GDBusProxy *dbus_proxy,
         emtr_event_recorder_record_event (emtr_event_recorder_get_default (),
                                           EMTR_EVENT_NETWORK_STATUS_CHANGED,
                                           status_change);
-        g_variant_unref (status_change);
 
         previous_network_state = new_network_state;
 


### PR DESCRIPTION
We were double-unreffing a GVariant because we passed a floating
reference to the event recorder API, transferring ownership to it.
We also called g_variant_unref explicitly, so the fix was simply to
remove the explicit call to g_variant_unref.

Also, add some missing whitespace.

[endlessm/eos-sdk#1896]
