### PR TITLE
Build-depend on eos-metrics 0.2.0

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: standard
 Maintainer: Kurt von Laven <kurt@endlessm.com>
 Build-Depends: debhelper (>= 9),
 	autotools-dev,
-	eos-metrics-0-dev,
+	eos-metrics-0-dev (>= 0.2.0),
 	libglib2.0-dev,
 	dh-autoreconf,
 	dh-systemd


### PR DESCRIPTION
In order to prevent upgrading before the newly organized metrics
library is available, we build-depend on 0.2.0

[endlessm/eos-sdk#2043]
