### PR TITLE
Fix build by adding compile-time flag.

### DIFF
--- a/src/Makefile.am.inc
+++ b/src/Makefile.am.inc
@@ -5,7 +5,10 @@ libexec_PROGRAMS = eos-metrics-instrumentation
 eos_metrics_instrumentation_SOURCES = src/eos-metrics-instrumentation.c
 
 # Pre-processor flags
-AM_CPPFLAGS = $(EOS_INSTRUMENTATION_CFLAGS)
+AM_CPPFLAGS = \
+	$(EOS_INSTRUMENTATION_CFLAGS) \
+	-D_POSIX_C_SOURCE=199309L \
+	$(NULL)
 
 # Libraries to link against
 eos_metrics_instrumentation_LDADD = $(EOS_INSTRUMENTATION_LIBS)


### PR DESCRIPTION
The build is broken because we fail to build with the appropriate POSIX_C_SOURCE
flag. This flag is needed in order to access some POSIX-only methods in a
library we depend on.

[endlessm/eos-sdk#2449]
