### PR TITLE
Use AC_PROG_CC_C99 to enable C99 features

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -81,9 +81,7 @@ PKG_PROG_PKG_CONFIG
 AC_CACHE_SAVE
 
 # Check that the compiler supports C99, and enable it in our CFLAGS
-AS_COMPILER_FLAGS(C99_CFLAGS, "-std=c99")
-C99_CFLAGS=${C99_CFLAGS#*  }
-CFLAGS="$CFLAGS $C99_CFLAGS"
+AC_PROG_CC_C99
 
 # Configure options
 # -----------------


### PR DESCRIPTION
This will use the argument -std=gnu99 for gcc, which will allow usage of
non-ISO POSIX features. Otherwise, we can't use emtr-util.h because
clockid_t is not defined in ISO C.

[endlessm/eos-sdk#2449]
