### PR TITLE
debian: Depend on eos-sdk-dev

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,6 +5,7 @@ Maintainer: Kurt von Laven <kurt@endlessm.com>
 Build-Depends: debhelper (>= 9),
 	autotools-dev,
 	eos-metrics-0-dev,
+	eos-sdk-0-dev (>= 0.0.0)
 	libglib2.0-dev,
 	dh-autoreconf,
 	dh-systemd


### PR DESCRIPTION
[endlessm/eos-shell#2264]
