### PR TITLE
Launch after event recorder daemon, and flush the system DBus connection on shutdown.

### DIFF
--- a/data/eos-metrics-instrumentation.service.in
+++ b/data/eos-metrics-instrumentation.service.in
@@ -1,8 +1,8 @@
 [Unit]
 Description=EndlessOS Metrics Instrumentation
-Requires=dbus.service
+Requires=dbus.service eos-metrics-event-recorder.service
 Wants=dbus-org.freedesktop.GeoClue2.service
-After=dbus.service dbus-org.freedesktop.GeoClue2.service
+After=dbus.service eos-metrics-event-recorder.service dbus-org.freedesktop.GeoClue2.service
 Before=dbus-org.freedesktop.login1.service systemd-logind.service systemd-user-sessions.service
 
 [Service]

--- a/src/eos-metrics-instrumentation.c
+++ b/src/eos-metrics-instrumentation.c
@@ -191,7 +191,8 @@ systemd_dbus_proxy_new (void)
                                      "org.freedesktop.systemd1",
                                      "/org/freedesktop/systemd1",
                                      "org.freedesktop.systemd1.Manager",
-                                     NULL /* GCancellable */, &error);
+                                     NULL /* GCancellable */,
+                                     &error);
     if (dbus_proxy == NULL)
       {
         g_warning ("Error creating GDBusProxy: %s.", error->message);
@@ -242,7 +243,8 @@ get_user_id (GVariant *session_parameters, guint32 *user_id)
                                      "org.freedesktop.login1",
                                      session_path,
                                      "org.freedesktop.DBus.Properties",
-                                     NULL /* GCancellable */, &error);
+                                     NULL /* GCancellable */,
+                                     &error);
     g_free (session_path);
 
     if (dbus_proxy == NULL)
@@ -254,7 +256,8 @@ get_user_id (GVariant *session_parameters, guint32 *user_id)
 
     GVariant *get_user_args =
       g_variant_new_parsed ("('org.freedesktop.login1.Session', 'User')");
-    GVariant *user_result = g_dbus_proxy_call_sync (dbus_proxy, "Get",
+    GVariant *user_result = g_dbus_proxy_call_sync (dbus_proxy,
+                                                    "Get",
                                                     get_user_args,
                                                     G_DBUS_CALL_FLAGS_NONE,
                                                     -1 /* timeout */,
@@ -366,7 +369,8 @@ inhibit_shutdown (GDBusProxy *dbus_proxy)
         GError *error = NULL;
         GUnixFDList *fd_list = NULL;
         GVariant *inhibitor_tuple =
-          g_dbus_proxy_call_with_unix_fd_list_sync (dbus_proxy, "Inhibit",
+          g_dbus_proxy_call_with_unix_fd_list_sync (dbus_proxy,
+                                                    "Inhibit",
                                                     inhibit_args,
                                                     G_DBUS_CALL_FLAGS_NONE,
                                                     -1 /* timeout */,
@@ -480,7 +484,8 @@ record_login (GDBusProxy *dbus_proxy,
       {
         GVariant *session_id = g_variant_get_child_value (parameters, 0);
         emtr_event_recorder_record_stop (emtr_event_recorder_get_default (),
-                                         USER_IS_LOGGED_IN, session_id,
+                                         USER_IS_LOGGED_IN,
+                                         session_id,
                                          NULL /* auxiliary_payload */);
         g_variant_unref (session_id);
       }
@@ -496,7 +501,8 @@ record_login (GDBusProxy *dbus_proxy,
           g_variant_new_uint32 (user_id) : NULL;
 
         emtr_event_recorder_record_start (emtr_event_recorder_get_default (),
-                                          USER_IS_LOGGED_IN, session_id,
+                                          USER_IS_LOGGED_IN,
+                                          session_id,
                                           user_id_variant);
         g_variant_unref (session_id);
       }
@@ -513,7 +519,8 @@ login_dbus_proxy_new (void)
                                      "org.freedesktop.login1",
                                      "/org/freedesktop/login1",
                                      "org.freedesktop.login1.Manager",
-                                     NULL /* GCancellable */, &error);
+                                     NULL /* GCancellable */,
+                                     &error);
     if (dbus_proxy == NULL)
       {
         g_warning ("Error creating GDBusProxy: %s\n", error->message);
@@ -569,7 +576,8 @@ network_dbus_proxy_new (void)
                                      "org.freedesktop.NetworkManager",
                                      "/org/freedesktop/NetworkManager",
                                      "org.freedesktop.NetworkManager",
-                                     NULL /* GCancellable */, &error);
+                                     NULL /* GCancellable */,
+                                     &error);
     if (dbus_proxy == NULL)
       {
         g_warning ("Error creating GDBusProxy: %s\n", error->message);

--- a/src/eos-metrics-instrumentation.c
+++ b/src/eos-metrics-instrumentation.c
@@ -139,6 +139,33 @@ set_start_time (void)
     start_time_set = eins_persistent_tally_get_tally (persistent_tally, NULL);
 }
 
+static void
+flush_system_dbus_connection (void)
+{
+    GError *error = NULL;
+    GDBusConnection *dbus_connection =
+      g_bus_get_sync (G_BUS_TYPE_SYSTEM, NULL /* GCancellable */, &error);
+
+    if (dbus_connection == NULL)
+      {
+        g_warning ("Couldn't get system DBus connection: %s.", error->message);
+        g_error_free (error);
+        return;
+      }
+
+    gboolean flush_succeeded =
+      g_dbus_connection_flush_sync (dbus_connection, NULL /* GCancellable */,
+                                    &error);
+    g_clear_object (&dbus_connection);
+
+    if (!flush_succeeded)
+      {
+        g_warning ("Couldn't flush system DBus connection: %s.",
+                   error->message);
+        g_error_free (error);
+      }
+}
+
 /*
  * Record a system shutdown event. Compute the length of time the system has
  * been on but not suspended using the global variable start_time. Add that time
@@ -174,6 +201,8 @@ record_shutdown (void)
                                       SHUTDOWN, uptime_tally_variant);
 
     g_object_unref (persistent_tally);
+
+    flush_system_dbus_connection ();
 }
 
 /*


### PR DESCRIPTION
Launch after event recorder daemon.

Since the metrics instrumentation daemon requires the event recorder
daemon in order to record any events, we make it list the event
recorder daemon as a dependency and ensure that the metrics
instrumentation daemon launches after and closes before the event
recorder daemon. This also helps the shutdown event have enough time to
be persisted to disk by the event recorder daemon since it is recorded
when the instrumentation daemon receives the SIGTERM signal from
systemd.


Flush the system DBus connection on shutdown.

This is important for ensuring that the shutdown event makes it to the
event recorder daemon in time to be flushed to disk before power is cut.

[endlessm/eos-sdk#2906]