### PR TITLE
Add python-dbusmock dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,6 +8,7 @@ Build-Depends: debhelper (>= 9),
 	eos-sdk-0-dev (>= 0.0.0),
 	geoclue-2.0,
 	libglib2.0-dev,
+	python-dbusmock,
 	dh-autoreconf,
 	dh-systemd
 


### PR DESCRIPTION
Needed for running tests now, since we start a mock system bus with mock
services on it.

[endlessm/eos-sdk#861]