### PR TITLE
Depend on version 0.3.0+ of event recorder API.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: standard
 Maintainer: Kurt von Laven <kurt@endlessm.com>
 Build-Depends: debhelper (>= 9),
 	autotools-dev,
-	eos-metrics-0-dev,
+	eos-metrics-0-dev (>= 0.3.0),
 	eos-sdk-0-dev (>= 0.0.0),
 	geoclue-2.0,
 	libglib2.0-dev,


### PR DESCRIPTION
New synchronous methods were added to the event recorder API in version
0.3.0. These methods are required in the instrumentation daemon for
robust recording of logout and shutdown.

[endlessm/eos-sdk#3029]