### PR TITLE
Avoid unnecessary error handling.

### DIFF
--- a/src/eins-persistent-tally.c
+++ b/src/eins-persistent-tally.c
@@ -207,20 +207,7 @@ read_tally (EinsPersistentTally *self)
 
   priv->tally = g_key_file_get_int64 (priv->key_file, GROUP, priv->key, &error);
   if (error != NULL)
-    {
-      if (g_error_matches (error, G_KEY_FILE_ERROR,
-                           G_KEY_FILE_ERROR_NOT_FOUND) ||
-          g_error_matches (error, G_KEY_FILE_ERROR,
-                           G_KEY_FILE_ERROR_GROUP_NOT_FOUND) ||
-          g_error_matches (error, G_KEY_FILE_ERROR,
-                           G_KEY_FILE_ERROR_KEY_NOT_FOUND))
-        {
-          g_error_free (error);
-          return write_tally (self, 0);
-        }
-
-      goto handle_failed_read;
-    }
+    goto handle_failed_read;
 
   priv->tally_cached = TRUE;
   return TRUE;

--- a/src/eins-persistent-tally.c
+++ b/src/eins-persistent-tally.c
@@ -158,14 +158,15 @@ write_tally (EinsPersistentTally *self,
       if (parent_path != NULL)
         {
           gint status_code = g_mkdir_with_parents (parent_path, MODE);
-          g_free (parent_path);
           if (status_code != 0)
             {
               gint error_number = errno;
+              g_free (parent_path);
               g_critical ("Failed to create directory. Error: %s.",
                           g_strerror (error_number));
               return FALSE;
             }
+          g_free (parent_path);
         }
     }
 

--- a/tests/test-persistent-tally.c
+++ b/tests/test-persistent-tally.c
@@ -177,21 +177,6 @@ test_persistent_tally_resets_when_no_file (Fixture      *fixture,
 }
 
 static void
-test_persistent_tally_resets_when_no_group (Fixture      *fixture,
-                                            gconstpointer unused)
-{
-  write_key_file (fixture, EMPTY_KEY_FILE);
-
-  gint64 tally = -1;
-  gboolean read_succeeded =
-    eins_persistent_tally_get_tally (fixture->persistent_tally, &tally);
-
-  g_assert_true (read_succeeded);
-
-  g_assert_cmpint (tally, ==, 0);
-}
-
-static void
 test_persistent_tally_aborts_when_corrupted (Fixture      *fixture,
                                              gconstpointer unused)
 {
@@ -231,8 +216,6 @@ main (int                argc,
                                   test_persistent_tally_can_add_to_tally);
   ADD_PERSISTENT_TALLY_TEST_FUNC ("/persistent-tally/resets-when-no-file",
                                   test_persistent_tally_resets_when_no_file);
-  ADD_PERSISTENT_TALLY_TEST_FUNC ("/persistent-tally/resets-when-no-group",
-                                  test_persistent_tally_resets_when_no_group);
   ADD_PERSISTENT_TALLY_TEST_FUNC ("/persistent-tally/aborts-when-corrupted",
                                   test_persistent_tally_aborts_when_corrupted);
 

--- a/tests/test-persistent-tally.c
+++ b/tests/test-persistent-tally.c
@@ -165,7 +165,7 @@ static void
 test_persistent_tally_resets_when_no_file (Fixture      *fixture,
                                            gconstpointer unused)
 {
-  g_unlink (fixture->tmp_path);
+  g_assert_cmpint (g_unlink (fixture->tmp_path), ==, 0);
 
   gint64 tally = -1;
   gboolean read_succeeded =


### PR DESCRIPTION
In general we don't want to attempt error handling in cases we never
expect to enter because they are very difficult to test. If the
persistent tally key isn't found even though the key file exists, then
most likely either there is a programmer error that we shouldn't mask,
or the key file has been tampered with, and we have little hope of
redemption.

[endlessm/eos-sdk#3040]