### PR TITLE
Fix syntax for g_variant_get() call

### DIFF
--- a/src/eos-metrics-instrumentation.c
+++ b/src/eos-metrics-instrumentation.c
@@ -446,7 +446,7 @@ login_dbus_proxy_new (void)
       }
 
     GVariantIter *session_iter;
-    g_variant_get (sessions, "a(susso)", &session_iter);
+    g_variant_get (sessions, "(a(susso))", &session_iter);
 
     const gchar *session_id;
     guint32 user_id;


### PR DESCRIPTION
We have a tuple here, so we should pass the right type, or we'll hit an
assertion.

[endlessm/eos-sdk#3477]