### PR TITLE
test-location: don't assume first events are location

### DIFF
--- a/tests/test-location.py
+++ b/tests/test-location.py
@@ -152,7 +152,7 @@ class TestLocationIntegration(dbusmock.DBusTestCase):
         Timeout after waiting for 20 seconds. Use like this:
             self.quit_on('MyMethod')
             self.mainloop.run()
-            # now MyMethod has been called
+            # Now MyMethod has been called.
         """
         self._quit_on_method = method_name
         GLib.timeout_add_seconds(20, self.fail, 'Test timed out after ' +


### PR DESCRIPTION
This test currently assumes the first events recorded by the daemon will
be the location ones. This is not true anymore now that we also record
OS name, version and personality.
Change the code to wait for the specific event UUID instead.

[endlessm/eos-shell#5585]