### PR TITLE
Fix syntax for g_variant_get()

### DIFF
--- a/src/eos-metrics-instrumentation.c
+++ b/src/eos-metrics-instrumentation.c
@@ -518,14 +518,14 @@ record_login (GDBusProxy *dbus_proxy,
     if (strcmp ("SessionRemoved", signal_name) == 0)
       {
         const gchar *session_id;
-        g_variant_get (parameters, "&s", &session_id);
+        g_variant_get (parameters, "(&s&o)", &session_id, NULL);
 
         remove_session (session_id);
       }
     else if (strcmp ("SessionNew", signal_name) == 0)
       {
         const gchar *session_id, *session_path;
-        g_variant_get (parameters, "&s&o", &session_id, &session_path);
+        g_variant_get (parameters, "(&s&o)", &session_id, &session_path);
 
         guint32 user_id;
         if (!get_user_id (session_path, &user_id))


### PR DESCRIPTION
These variants are tuples, so we should use the correct type syntax;
also the "SessionRemoved" signal carries two arguments.

[endlessm/eos-shell#5585]