### PR TITLE
Record uptime event and boot count.

### DIFF
--- a/src/eins-location.c
+++ b/src/eins-location.c
@@ -51,7 +51,7 @@ on_location_proxy_ready (GObject      *obj,
   if (error != NULL)
     {
       if (!g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CANCELLED))
-        g_critical ("Failed to get location from GeoClue: %s", error->message);
+        g_critical ("Failed to get location from GeoClue: %s.", error->message);
       g_error_free (error);
       return;
     }
@@ -97,7 +97,7 @@ on_start_ready (GeoclueClient *client,
   if (!geoclue_client_call_start_finish (client, res, &error))
     {
       if (!g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CANCELLED))
-        g_critical ("Failed to start GeoClue2 client: %s", error->message);
+        g_critical ("Failed to start GeoClue2 client: %s.", error->message);
       g_error_free (error);
     }
 }
@@ -112,7 +112,7 @@ on_client_proxy_ready (GObject      *obj,
   if (error != NULL)
     {
       if (!g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CANCELLED))
-        g_critical ("Failed to get GeoClue client: %s", error->message);
+        g_critical ("Failed to get GeoClue client: %s.", error->message);
       g_error_free (error);
       return;
     }
@@ -140,7 +140,7 @@ on_get_client_ready (GeoclueManager *manager,
                                                &error))
     {
       if (!g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CANCELLED))
-        g_critical ("Failed to get GeoClue client: %s", error->message);
+        g_critical ("Failed to get GeoClue client: %s.", error->message);
       g_error_free (error);
       return;
     }
@@ -165,7 +165,8 @@ on_manager_proxy_ready (GObject      *obj,
   if (error != NULL)
     {
       if (!g_error_matches (error, G_IO_ERROR, G_IO_ERROR_CANCELLED))
-        g_critical ("Failed to get GeoClue manager object: %s", error->message);
+        g_critical ("Failed to get GeoClue manager object: %s.",
+                    error->message);
       g_error_free (error);
       return;
     }

--- a/src/eos-metrics-instrumentation.c
+++ b/src/eos-metrics-instrumentation.c
@@ -186,14 +186,14 @@ get_eos_personality (void)
     return (personality != NULL) ? personality : g_strdup ("");
 }
 
-static void
-record_os_version (void)
+static gboolean
+record_os_version (gpointer unused)
 {
     gchar *os_name = NULL;
     gchar *os_version = NULL;
 
     if (!get_os_version (&os_name, &os_version))
-      return;
+      return G_SOURCE_REMOVE;
 
     gchar *eos_personality = get_eos_personality ();
 
@@ -205,6 +205,8 @@ record_os_version (void)
     g_free (os_name);
     g_free (os_version);
     g_free (eos_personality);
+
+    return G_SOURCE_REMOVE;
 }
 
 /*
@@ -662,15 +664,15 @@ main (gint                argc,
     GDBusProxy *network_dbus_proxy = network_dbus_proxy_new ();
 
     GMainLoop *main_loop = g_main_loop_new (NULL, TRUE);
+
     g_idle_add ((GSourceFunc) record_location_metric, NULL);
+    g_idle_add ((GSourceFunc) record_os_version, NULL);
 
     g_unix_signal_add (SIGHUP, (GSourceFunc) quit_main_loop, main_loop);
     g_unix_signal_add (SIGINT, (GSourceFunc) quit_main_loop, main_loop);
     g_unix_signal_add (SIGTERM, (GSourceFunc) quit_main_loop, main_loop);
     g_unix_signal_add (SIGUSR1, (GSourceFunc) quit_main_loop, main_loop);
     g_unix_signal_add (SIGUSR2, (GSourceFunc) quit_main_loop, main_loop);
-
-    record_os_version ();
 
     g_main_loop_run (main_loop);
 

--- a/src/eos-metrics-instrumentation.c
+++ b/src/eos-metrics-instrumentation.c
@@ -252,7 +252,7 @@ set_start_time (void)
     start_time_set = emtr_util_get_current_time (CLOCK_MONOTONIC, &start_time);
 
     const gchar *tally_file_override = g_getenv ("EOS_INSTRUMENTATION_CACHE");
-    if (tally_file_override)
+    if (tally_file_override != NULL)
       persistent_tally = eins_persistent_tally_new_full (tally_file_override,
                                                          UPTIME_KEY);
     else

--- a/src/eos-metrics-instrumentation.c
+++ b/src/eos-metrics-instrumentation.c
@@ -43,7 +43,7 @@
  * signed integer. This running total accumulates across boots and excludes time
  * the computer spends suspended.
  */
-#define SHUTDOWN "ae391c82-1937-4ae5-8539-8d1aceed037d"
+#define SHUTDOWN_EVENT "ae391c82-1937-4ae5-8539-8d1aceed037d"
 
 #define UPTIME_KEY "uptime"
 
@@ -297,7 +297,8 @@ record_shutdown (void)
 
     GVariant *uptime_tally_variant = g_variant_new_int64 (uptime_tally);
     emtr_event_recorder_record_event_sync (emtr_event_recorder_get_default (),
-                                           SHUTDOWN, uptime_tally_variant);
+                                           SHUTDOWN_EVENT,
+                                           uptime_tally_variant);
 
     g_object_unref (persistent_tally);
 }

--- a/src/eos-metrics-instrumentation.c
+++ b/src/eos-metrics-instrumentation.c
@@ -251,7 +251,7 @@ set_start_time (void)
 {
     start_time_set = emtr_util_get_current_time (CLOCK_MONOTONIC, &start_time);
 
-    const gchar *tally_file_override = g_getenv("EOS_INSTRUMENTATION_CACHE");
+    const gchar *tally_file_override = g_getenv ("EOS_INSTRUMENTATION_CACHE");
     if (tally_file_override)
       persistent_tally = eins_persistent_tally_new_full (tally_file_override,
                                                          UPTIME_KEY);

--- a/src/eos-metrics-instrumentation.c
+++ b/src/eos-metrics-instrumentation.c
@@ -371,7 +371,7 @@ get_user_id (const gchar *session_path,
 
     if (dbus_proxy == NULL)
       {
-        g_warning ("Error creating GDBusProxy: %s\n", error->message);
+        g_warning ("Error creating GDBusProxy: %s.", error->message);
         g_error_free (error);
         return FALSE;
       }
@@ -389,7 +389,7 @@ get_user_id (const gchar *session_path,
 
     if (user_result == NULL)
       {
-        g_warning ("Error getting user ID: %s\n", error->message);
+        g_warning ("Error getting user ID: %s.", error->message);
         g_error_free (error);
         return FALSE;
       }
@@ -634,7 +634,7 @@ network_dbus_proxy_new (void)
                                      &error);
     if (dbus_proxy == NULL)
       {
-        g_warning ("Error creating GDBusProxy: %s\n", error->message);
+        g_warning ("Error creating GDBusProxy: %s.", error->message);
         g_error_free (error);
       }
     else

--- a/src/eos-metrics-instrumentation.c
+++ b/src/eos-metrics-instrumentation.c
@@ -652,9 +652,9 @@ quit_main_loop (GMainLoop *main_loop)
     return G_SOURCE_REMOVE;
 }
 
-int
-main(int                argc,
-     const char * const argv[])
+gint
+main (gint                argc,
+      const gchar * const argv[])
 {
     set_start_time ();
     g_datalist_init (&humanity_by_session_id);

--- a/src/eos-metrics-instrumentation.c
+++ b/src/eos-metrics-instrumentation.c
@@ -43,7 +43,7 @@
  * signed integer. This running total accumulates across boots and excludes time
  * the computer spends suspended.
  */
-# define SHUTDOWN "ae391c82-1937-4ae5-8539-8d1aceed037d"
+#define SHUTDOWN "ae391c82-1937-4ae5-8539-8d1aceed037d"
 
 #define UPTIME_KEY "uptime"
 

--- a/src/eos-metrics-instrumentation.c
+++ b/src/eos-metrics-instrumentation.c
@@ -86,7 +86,7 @@ static gint64 start_time;
 
 static EinsPersistentTally *persistent_tally;
 
-static volatile guint32 previous_network_state = 0; // NM_STATE_UNKNOWM
+static guint32 previous_network_state = 0; // NM_STATE_UNKNOWM
 
 static gboolean
 get_os_version (gchar **name_out,

--- a/src/eos-metrics-instrumentation.c
+++ b/src/eos-metrics-instrumentation.c
@@ -78,13 +78,11 @@
 #define PERSONALITY_CONFIG_GROUP "Personality"
 #define PERSONALITY_KEY "PersonalityName"
 
-static GData *humanity_by_session_id;
-
 static gboolean start_time_set = FALSE;
-
 static gint64 start_time;
-
 static EinsPersistentTally *persistent_tally;
+
+static GData *humanity_by_session_id;
 
 static guint32 previous_network_state = 0; // NM_STATE_UNKNOWM
 

--- a/src/eos-metrics-instrumentation.c
+++ b/src/eos-metrics-instrumentation.c
@@ -86,6 +86,8 @@ static gint64 start_time;
 
 static EinsPersistentTally *persistent_tally;
 
+static volatile guint32 previous_network_state = 0; // NM_STATE_UNKNOWM
+
 static gboolean
 get_os_version (gchar **name_out,
                 gchar **version_out)
@@ -593,8 +595,6 @@ login_dbus_proxy_new (void)
 
     return dbus_proxy;
 }
-
-static volatile guint32 previous_network_state = 0; // NM_STATE_UNKNOWM
 
 static void
 record_network_change (GDBusProxy *dbus_proxy,

--- a/tests/test-persistent-tally.c
+++ b/tests/test-persistent-tally.c
@@ -196,11 +196,11 @@ test_persistent_tally_aborts_when_corrupted (Fixture      *fixture,
   g_test_assert_expected_messages ();
 }
 
-int
-main (int                argc,
-      const char * const argv[])
+gint
+main (gint                argc,
+      const gchar * const argv[])
 {
-  g_test_init (&argc, (char ***) &argv, NULL);
+  g_test_init (&argc, (gchar ***) &argv, NULL);
 #define ADD_PERSISTENT_TALLY_TEST_FUNC(path, func) \
   g_test_add ((path), Fixture, NULL, setup, (func), teardown)
 


### PR DESCRIPTION
The shutdown event is unreliable because dirty shutdowns are too
frequent. The uptime event and boot count will help us more reliably
estimate the total time the machine has been on. This value is of
interest because it constitutes the denominator of the connectivity
estimate.

[endlessm/eos-sdk#3741]