### PR TITLE
Fix bug causing null payload for uptime events.

### DIFF
--- a/src/eins-persistent-tally.c
+++ b/src/eins-persistent-tally.c
@@ -208,7 +208,16 @@ read_tally (EinsPersistentTally *self)
 
   priv->tally = g_key_file_get_int64 (priv->key_file, GROUP, priv->key, &error);
   if (error != NULL)
-    goto handle_failed_read;
+    {
+      if (g_error_matches (error, G_KEY_FILE_ERROR,
+                           G_KEY_FILE_ERROR_KEY_NOT_FOUND))
+        {
+          g_error_free (error);
+          return write_tally (self, 0);
+        }
+
+      goto handle_failed_read;
+    }
 
   priv->tally_cached = TRUE;
   return TRUE;

--- a/src/eos-metrics-instrumentation.c
+++ b/src/eos-metrics-instrumentation.c
@@ -42,7 +42,7 @@
  * uptime_tally is a running total of the system uptime in nanoseconds as a
  * 64-bit signed integer. This running total accumulates across boots and
  * excludes time the computer spends suspended. boot_count is a 64-bit signed
- * integer indicating the 0-based count of the current boot.
+ * integer indicating the 1-based count of the current boot.
  */
 #define UPTIME_EVENT "005096c4-9444-48c6-844b-6cb693c15235"
 
@@ -304,7 +304,7 @@ set_boot_count (gpointer unused)
 /* Returns an auxiliary payload that is a 2-tuple of the form
  * (uptime_tally, boot_count). uptime_tally is the running total uptime across
  * all boots in nanoseconds as a 64-bit signed integer. boot_count is the
- * 0-based count associated with the current boot as a 64-bit signed integer.
+ * 1-based count associated with the current boot as a 64-bit signed integer.
  * Returns NULL on error. Sets the global variable prev_time to the current
  * time. Adds the time elapsed since prev_time to the running uptime tally that
  * spans boots.


### PR DESCRIPTION
All the auxiliary payloads of the uptime events in the metrics databases
are null. We need to handle the case where the persistent tally key file
already exists but does not yet contain the boot_time key.