### PR TITLE
Fix handling of multiple keys in persistent tally.

### DIFF
--- a/src/eins-persistent-tally.c
+++ b/src/eins-persistent-tally.c
@@ -26,12 +26,14 @@ typedef struct EinsPersistentTallyPrivate
 {
   GKeyFile *key_file;
   gchar *file_path;
-  gchar *key;
-  gint64 tally;
-  gboolean tally_cached;
 } EinsPersistentTallyPrivate;
 
-G_DEFINE_TYPE_WITH_PRIVATE (EinsPersistentTally, eins_persistent_tally, G_TYPE_OBJECT)
+static void eins_persistent_tally_initable_iface_init (GInitableIface *iface);
+
+G_DEFINE_TYPE_WITH_CODE (EinsPersistentTally, eins_persistent_tally,
+                         G_TYPE_OBJECT,
+                         G_ADD_PRIVATE (EinsPersistentTally)
+                         G_IMPLEMENT_INTERFACE (G_TYPE_INITABLE, eins_persistent_tally_initable_iface_init))
 
 /* The path to the key file containing the running tally. */
 #define DEFAULT_FILE_PATH INSTRUMENTATION_CACHE_DIR "persistent-tallies"
@@ -43,7 +45,6 @@ G_DEFINE_TYPE_WITH_PRIVATE (EinsPersistentTally, eins_persistent_tally, G_TYPE_O
 enum {
   PROP_0,
   PROP_FILE_PATH,
-  PROP_KEY,
   NPROPS
 };
 
@@ -65,10 +66,6 @@ eins_persistent_tally_set_property (GObject      *object,
       priv->file_path = g_value_dup_string (value);
       break;
 
-    case PROP_KEY:
-      priv->key = g_value_dup_string (value);
-      break;
-
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, property_id, pspec);
       break;
@@ -84,7 +81,6 @@ eins_persistent_tally_finalize (GObject *object)
 
   g_key_file_unref (priv->key_file);
   g_free (priv->file_path);
-  g_free (priv->key);
 
   G_OBJECT_CLASS (eins_persistent_tally_parent_class)->finalize (object);
 }
@@ -98,12 +94,6 @@ eins_persistent_tally_class_init (EinsPersistentTallyClass *klass)
     g_param_spec_string ("file-path", "File path",
                          "The path to the file where the tally is stored.",
                          DEFAULT_FILE_PATH,
-                         G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS);
-
-  eins_persistent_tally_props[PROP_KEY] =
-    g_param_spec_string ("key", "Key",
-                         "Used to lookup a specific tally in the file.",
-                         NULL,
                          G_PARAM_WRITABLE | G_PARAM_CONSTRUCT_ONLY | G_PARAM_STATIC_STRINGS);
 
   object_class->set_property = eins_persistent_tally_set_property;
@@ -122,30 +112,106 @@ eins_persistent_tally_init (EinsPersistentTally *self)
   priv->key_file = g_key_file_new ();
 }
 
-EinsPersistentTally *
-eins_persistent_tally_new (const gchar *key)
+static gboolean
+eins_persistent_tally_initable_init (GInitable    *initable,
+                                     GCancellable *cancellable,
+                                     GError      **error)
 {
-  return g_object_new (EINS_TYPE_PERSISTENT_TALLY,
-                       "key", key,
-                       NULL);
+  EinsPersistentTally *self = EINS_PERSISTENT_TALLY (initable);
+  EinsPersistentTallyPrivate *priv =
+    eins_persistent_tally_get_instance_private (self);
+
+  GError *local_error = NULL;
+  if (g_key_file_load_from_file (priv->key_file, priv->file_path,
+                                 G_KEY_FILE_NONE, &local_error))
+    return TRUE;
+
+  if (g_error_matches (local_error, G_FILE_ERROR, G_FILE_ERROR_NOENT))
+    {
+      g_error_free (local_error);
+      return TRUE;
+    }
+
+  g_propagate_error (error, local_error);
+  return FALSE;
+}
+
+static void
+eins_persistent_tally_initable_iface_init (GInitableIface *iface)
+{
+  iface->init = eins_persistent_tally_initable_init;
+}
+
+EinsPersistentTally *
+eins_persistent_tally_new (GError **error)
+{
+  return g_initable_new (EINS_TYPE_PERSISTENT_TALLY,
+                         NULL /* GCancellable*/,
+                         error,
+                         NULL);
 }
 
 EinsPersistentTally *
 eins_persistent_tally_new_full (const gchar *file_path,
-                                const gchar *key)
+                                GError     **error)
 {
-  return g_object_new (EINS_TYPE_PERSISTENT_TALLY,
-                       "file-path", file_path,
-                       "key", key,
-                       NULL);
+  return g_initable_new (EINS_TYPE_PERSISTENT_TALLY,
+                         NULL /* GCancellable */,
+                         error,
+                         "file-path", file_path,
+                         NULL);
 }
 
-static gboolean
-write_tally (EinsPersistentTally *self,
-             gint64               tally)
+/*
+ * Populates tally with the current value of the tally associated with the given
+ * key. Returns TRUE if the tally was successfully retrieved and FALSE
+ * otherwise.
+ */
+gboolean
+eins_persistent_tally_get_tally (EinsPersistentTally *self,
+                                 const gchar         *key,
+                                 gint64              *tally)
 {
   EinsPersistentTallyPrivate *priv =
     eins_persistent_tally_get_instance_private (self);
+
+  GError *error = NULL;
+  *tally = g_key_file_get_int64 (priv->key_file, GROUP, key, &error);
+  if (error != NULL)
+    {
+      if (g_error_matches (error, G_KEY_FILE_ERROR,
+                           G_KEY_FILE_ERROR_KEY_NOT_FOUND) ||
+          g_error_matches (error, G_KEY_FILE_ERROR,
+                           G_KEY_FILE_ERROR_GROUP_NOT_FOUND))
+        {
+          g_error_free (error);
+          return TRUE;
+        }
+
+      g_warning ("Could not get tally for key %s. Error: %s.", key,
+                 error->message);
+      g_error_free (error);
+      return FALSE;
+    }
+
+  return TRUE;
+}
+
+/*
+ * Adds the given delta to the persistent tally associated with the given key.
+ * Returns TRUE on success and FALSE on failure.
+ */
+gboolean
+eins_persistent_tally_add_to_tally (EinsPersistentTally *self,
+                                    const gchar         *key,
+                                    gint64               delta)
+{
+  EinsPersistentTallyPrivate *priv =
+    eins_persistent_tally_get_instance_private (self);
+
+  gint64 tally;
+  if (!eins_persistent_tally_get_tally (self, key, &tally))
+    return FALSE;
 
   GFile *file = g_file_new_for_path (priv->file_path);
   GFile *parent_file = g_file_get_parent (file);
@@ -171,7 +237,7 @@ write_tally (EinsPersistentTally *self,
         }
     }
 
-  g_key_file_set_int64 (priv->key_file, GROUP, priv->key, tally);
+  g_key_file_set_int64 (priv->key_file, GROUP, key, tally + delta);
 
   GError *error = NULL;
   if (!g_key_file_save_to_file (priv->key_file, priv->file_path, &error))
@@ -181,89 +247,5 @@ write_tally (EinsPersistentTally *self,
       return FALSE;
     }
 
-  priv->tally = tally;
-  priv->tally_cached = TRUE;
   return TRUE;
-}
-
-static gboolean
-read_tally (EinsPersistentTally *self)
-{
-  EinsPersistentTallyPrivate *priv =
-    eins_persistent_tally_get_instance_private (self);
-
-  if (priv->tally_cached)
-    return TRUE;
-
-  GError *error = NULL;
-  if (!g_key_file_load_from_file (priv->key_file, priv->file_path,
-                                  G_KEY_FILE_NONE, &error))
-    {
-      if (g_error_matches (error, G_FILE_ERROR, G_FILE_ERROR_NOENT))
-        {
-          g_error_free (error);
-          return write_tally (self, 0);
-        }
-
-      goto handle_failed_read;
-    }
-
-  priv->tally = g_key_file_get_int64 (priv->key_file, GROUP, priv->key, &error);
-  if (error != NULL)
-    {
-      if (g_error_matches (error, G_KEY_FILE_ERROR,
-                           G_KEY_FILE_ERROR_KEY_NOT_FOUND))
-        {
-          g_error_free (error);
-          return write_tally (self, 0);
-        }
-
-      goto handle_failed_read;
-    }
-
-  priv->tally_cached = TRUE;
-  return TRUE;
-
-handle_failed_read:
-  g_warning ("Failed to read from file. Error: %s", error->message);
-  g_error_free (error);
-  return FALSE;
-}
-
-/*
- * Populates tally with the current value of the tally unless tally is NULL.
- * Returns TRUE if the tally was successfully retrieved and FALSE otheriwse.
- * If FALSE is returned, tally is not modified.
- */
-gboolean
-eins_persistent_tally_get_tally (EinsPersistentTally *self,
-                                 gint64              *tally)
-{
-  EinsPersistentTallyPrivate *priv =
-    eins_persistent_tally_get_instance_private (self);
-
-  if (!read_tally (self))
-    return FALSE;
-
-  if (tally != NULL)
-    *tally = priv->tally;
-
-  return TRUE;
-}
-
-/*
- * Adds the given delta to the persistent tally.
- * Returns TRUE on success and FALSE on failure.
- */
-gboolean
-eins_persistent_tally_add_to_tally (EinsPersistentTally *self,
-                                    gint64               delta)
-{
-  EinsPersistentTallyPrivate *priv =
-    eins_persistent_tally_get_instance_private (self);
-
-  if (!read_tally (self))
-    return FALSE;
-
-  return write_tally (self, priv->tally + delta);
 }

--- a/src/eins-persistent-tally.c
+++ b/src/eins-persistent-tally.c
@@ -118,6 +118,7 @@ eins_persistent_tally_init (EinsPersistentTally *self)
 {
   EinsPersistentTallyPrivate *priv =
     eins_persistent_tally_get_instance_private (self);
+
   priv->key_file = g_key_file_new ();
 }
 
@@ -171,6 +172,7 @@ write_tally (EinsPersistentTally *self,
     }
 
   g_key_file_set_int64 (priv->key_file, GROUP, priv->key, tally);
+
   GError *error = NULL;
   if (!g_key_file_save_to_file (priv->key_file, priv->file_path, &error))
     {

--- a/src/eins-persistent-tally.h
+++ b/src/eins-persistent-tally.h
@@ -47,15 +47,17 @@ struct _EinsPersistentTallyClass
 
 GType                eins_persistent_tally_get_type     (void) G_GNUC_CONST;
 
-EinsPersistentTally *eins_persistent_tally_new          (const gchar         *key);
+EinsPersistentTally *eins_persistent_tally_new          (GError             **error);
 
 EinsPersistentTally *eins_persistent_tally_new_full     (const gchar         *file_path,
-                                                         const gchar         *key);
+                                                         GError             **error);
 
 gboolean             eins_persistent_tally_get_tally    (EinsPersistentTally *self,
+                                                         const gchar         *key,
                                                          gint64              *tally);
 
 gboolean             eins_persistent_tally_add_to_tally (EinsPersistentTally *self,
+                                                         const gchar         *key,
                                                          gint64               delta);
 
 G_END_DECLS

--- a/tests/test-persistent-tally.c
+++ b/tests/test-persistent-tally.c
@@ -189,11 +189,9 @@ test_persistent_tally_aborts_when_corrupted (Fixture      *fixture,
   gboolean read_succeeded =
     eins_persistent_tally_get_tally (fixture->persistent_tally, &tally);
 
-  g_assert_false (read_succeeded);
-
-  g_assert_cmpint (tally, ==, -1);
-
   g_test_assert_expected_messages ();
+  g_assert_false (read_succeeded);
+  g_assert_cmpint (tally, ==, -1);
 }
 
 gint


### PR DESCRIPTION
Previously persistent tally objects were 1:1 with keys in key files, but
this led to race conditions when multiple objects were backed by the
same key file. As a consequence, the boot count incremented very rarely.
Since the boot count is unusable before this commit, we assign a new
event ID to the uptime and shutdown events. This will allow us to
distinguish between events with invalid boot counts and events with
valid boot counts on the server.

[endlessm/eos-sdk#3848]