### PR TITLE
data: delay gathering metrics until FBE is complete

### DIFF
--- a/data/Makefile.am.inc
+++ b/data/Makefile.am.inc
@@ -17,7 +17,9 @@
 ## <http://www.gnu.org/licenses/>.
 
 # Defined as systemdsystemunitdir in ../configure.ac.
-systemdsystemunit_DATA = data/eos-metrics-instrumentation.service
+systemdsystemunit_DATA = \
+	data/eos-metrics-instrumentation.path \
+	data/eos-metrics-instrumentation.service
 
 data/eos-metrics-instrumentation.%: data/eos-metrics-instrumentation.%.in
 	$(AM_V_GEN)mkdir -p data && \
@@ -34,11 +36,13 @@ tmpfilesddir = $(prefix)/lib/tmpfiles.d/
 tmpfilesd_DATA = data/eos-metrics-instrumentation.conf
 
 EXTRA_DIST += \
+	data/eos-metrics-instrumentation.path.in \
 	data/eos-metrics-instrumentation.service.in \
 	data/eos-metrics-instrumentation.conf.in \
 	$(NULL)
 
 CLEANFILES += \
+	data/eos-metrics-instrumentation.path \
 	data/eos-metrics-instrumentation.service \
 	data/eos-metrics-instrumentation.conf \
 	$(NULL)

--- a/data/Makefile.am.inc
+++ b/data/Makefile.am.inc
@@ -19,14 +19,8 @@
 # Defined as systemdsystemunitdir in ../configure.ac.
 systemdsystemunit_DATA = data/eos-metrics-instrumentation.service
 
-data/eos-metrics-instrumentation.service: data/eos-metrics-instrumentation.service.in
+data/eos-metrics-instrumentation.%: data/eos-metrics-instrumentation.%.in
 	$(AM_V_GEN)mkdir -p data && \
-	rm -f $@ $@.tmp && \
-	$(edit) $< >$@.tmp && \
-	mv $@.tmp $@
-
-data/eos-metrics-instrumentation.conf: data/eos-metrics-instrumentation.conf.in
-	$(AM_V_GEN)$(MKDIR_P) data && \
 	rm -f $@ $@.tmp && \
 	$(edit) $< >$@.tmp && \
 	mv $@.tmp $@

--- a/data/eos-metrics-instrumentation.path.in
+++ b/data/eos-metrics-instrumentation.path.in
@@ -1,0 +1,10 @@
+[Unit]
+Description=Endless OS Metrics Instrumentation trigger
+Wants=geoclue.service
+After=eos-metrics-event-recorder.service
+
+[Path]
+DirectoryNotEmpty=/home
+
+[Install]
+WantedBy=multi-user.target

--- a/data/eos-metrics-instrumentation.service.in
+++ b/data/eos-metrics-instrumentation.service.in
@@ -1,12 +1,10 @@
 [Unit]
-Description=EndlessOS Metrics Instrumentation
+Description=Endless OS Metrics Instrumentation
 Requires=eos-metrics-event-recorder.service
 Wants=geoclue.service
 After=eos-metrics-event-recorder.service
+ConditionDirectoryNotEmpty=/home
 
 [Service]
 Type=simple
 ExecStart=@libexecdir@/eos-metrics-instrumentation
-
-[Install]
-WantedBy=multi-user.target


### PR DESCRIPTION
The metrics daemon is disabled by default. The first-boot experience shows
a checkbox asking the user whether to enable metrics, which defaults to
checked. At the time the FBE loads, the checkbox state is synced to the
metrics daemon, enabling it.

eos-metrics-instrumentation currently runs before the FBE loads. As a
result, the first set of boot-time metrics are discarded. On live boots,
this is equivalent to all boot-time metrics being discarded.

Instead, we use a path unit to trigger boot-time metrics collection when
/home is non-empty. On the first boot, this will be true when the FBE is
completed; on subsequent boots, this will be true at boot time.

This is the same technique we use for eos-phone-home.

https://phabricator.endlessm.com/T14065