### PR TITLE
Weaken a hwinfo test

### DIFF
--- a/src/eins-hwinfo.c
+++ b/src/eins-hwinfo.c
@@ -370,7 +370,7 @@ GVariant *
 eins_hwinfo_get_cpu_info (void)
 {
   g_autoptr(GSubprocess) lscpu = NULL;
-  g_autoptr(GBytes) lsusb_stdout = NULL;
+  g_autoptr(GBytes) lscpu_stdout = NULL;
   g_autoptr(JsonParser) parser = json_parser_new ();
   const gchar *json_data = NULL;
   gsize json_size;
@@ -383,7 +383,7 @@ eins_hwinfo_get_cpu_info (void)
       || !g_subprocess_communicate (lscpu,
                                     NULL /* stdin */,
                                     NULL /* cancellable */,
-                                    &lsusb_stdout,
+                                    &lscpu_stdout,
                                     NULL /* stderr */,
                                     &error)
       || !g_subprocess_wait_check (lscpu, NULL /* cancellable */, &error))
@@ -392,7 +392,7 @@ eins_hwinfo_get_cpu_info (void)
       return NULL;
     }
 
-  json_data = g_bytes_get_data (lsusb_stdout, &json_size);
+  json_data = g_bytes_get_data (lscpu_stdout, &json_size);
   g_return_val_if_fail (json_size <= G_MAXSSIZE, NULL);
   return eins_hwinfo_parse_lscpu_json (json_data, (gssize) json_size);
 }

--- a/src/eins-hwinfo.c
+++ b/src/eins-hwinfo.c
@@ -74,7 +74,10 @@
  * ------+--------+--------------------------+-------------------
  *     0 | string | Human-readable CPU model | ''
  *     1 | uint16 | Number of cores/threads  | 0
- *     2 | double | Maximum speed in MHz     | 0.
+ *     2 | double | Maximum¹ speed in MHz    | 0.
+ *
+ * ¹ If the maximum speed can't be determined, we report the current speed
+ *   instead, if known.
  *
  * For example, a laptop fitted with an i7-5500U (which has 2 physical cores,
  * each with 2 threads) will be reported as:

--- a/tests/test-hwinfo.c
+++ b/tests/test-hwinfo.c
@@ -225,7 +225,7 @@ test_get_cpu_info_for_current_system (void)
   g_variant_get_child (payload, 0, "(&sqd)", &model, &n_cpus, &max_mhz);
   g_assert_cmpstr (model, !=, "");
   g_assert_cmpuint (n_cpus, >, 0);
-  g_assert_cmpfloat (max_mhz, >, 0);
+  g_assert_cmpfloat (max_mhz, >=, 0);
 }
 
 int

--- a/tests/test-hwinfo.c
+++ b/tests/test-hwinfo.c
@@ -130,6 +130,28 @@ static const char *NO_CPU_MAX_MHZ_VARIANT =
     "  2385.484"
     ")]";
 
+static const char *ROCKCHIP_JSON =
+    "{"
+    "   \"lscpu\": ["
+    "      {\"field\": \"Architecture:\", \"data\": \"armv7l\"},"
+    "      {\"field\": \"Byte Order:\", \"data\": \"Little Endian\"},"
+    "      {\"field\": \"CPU(s):\", \"data\": \"4\"},"
+    "      {\"field\": \"On-line CPU(s) list:\", \"data\": \"0-3\"},"
+    "      {\"field\": \"Thread(s) per core:\", \"data\": \"1\"},"
+    "      {\"field\": \"Core(s) per socket:\", \"data\": \"4\"},"
+    "      {\"field\": \"Socket(s):\", \"data\": \"1\"},"
+    "      {\"field\": \"Vendor ID:\", \"data\": \"ARM\"},"
+    "      {\"field\": \"Model:\", \"data\": \"1\"},"
+    "      {\"field\": \"Model name:\", \"data\": \"Cortex-A12\"},"
+    "      {\"field\": \"Stepping:\", \"data\": \"r0p1\"},"
+    "      {\"field\": \"CPU max MHz:\", \"data\": \"1608.0000\"},"
+    "      {\"field\": \"CPU min MHz:\", \"data\": \"126.0000\"},"
+    "      {\"field\": \"BogoMIPS:\", \"data\": \"35.82\"},"
+    "      {\"field\": \"Flags:\", \"data\": \"half thumb fastmult vfp edsp thumbee neon vfpv3 tls vfpv4 idiva idivt vfpd32 lpae evtstrm\"}"
+    "   ]"
+    "}";
+static const char *ROCKCHIP_VARIANT = "[('Cortex-A12', 4,  1608.)]";
+
 static const char *MALFORMED_JSON = "{";
 static const char *WRONG_STRUCTURE_JSON_1 = "[]";
 static const char *WRONG_STRUCTURE_JSON_2 = "{}";
@@ -227,6 +249,7 @@ main (int   argc,
 
       { "/hwinfo/cpu/good/xps13", XPS_13_9343_JSON, XPS_13_9343_VARIANT },
       { "/hwinfo/cpu/good/no-cpu-max-mhz", NO_CPU_MAX_MHZ_JSON, NO_CPU_MAX_MHZ_VARIANT },
+      { "/hwinfo/cpu/good/rockchip", ROCKCHIP_JSON, ROCKCHIP_VARIANT },
   };
   size_t i;
 


### PR DESCRIPTION
This was failing on an ARM OBS builder. I don't really care whether we can determine the CPU speed on our OBS builder.

To atone for this slight sin, I added some test data collected from an ARM laptop.

https://phabricator.endlessm.com/T18445