### PR TITLE
network ID: Hardcode fnde and impact images as Solutions images

### DIFF
--- a/src/eins-location.c
+++ b/src/eins-location.c
@@ -180,20 +180,20 @@ on_manager_proxy_ready (GObject      *obj,
 /*
  * record_location_metric:
  *
- * Access GeoClue to record the user's location, on Solutions systems only.
+ * Access GeoClue to record the user's location, on certain partner images only.
  *
  * Returns: %G_SOURCE_REMOVE for use as an idle function.
  */
 gboolean
 record_location_metric (const char *image_version)
 {
-  /* Location is only needed for analysis on Solutions images */
+  /* Location is only needed for analysis on certain partner images */
   if (!image_version ||
       !(g_str_has_prefix (image_version, "fnde-") ||
         g_str_has_prefix (image_version, "impact-") ||
         g_str_has_prefix (image_version, "solutions-")))
     {
-      g_message ("Not recording location as this is not a Solutions system");
+      g_message ("Not recording location as it is not required for this image");
       return G_SOURCE_REMOVE;
     }
 

--- a/src/eos-metrics-instrumentation.c
+++ b/src/eos-metrics-instrumentation.c
@@ -892,13 +892,13 @@ record_network_id_impl (const char *image_version,
 {
   guint32 network_id;
 
-  /* Network ID is only needed for analysis on Solutions images */
+  /* Network ID is only needed for analysis on certain partner images */
   if (!image_version ||
       !(g_str_has_prefix (image_version, "fnde-") ||
         g_str_has_prefix (image_version, "impact-") ||
         g_str_has_prefix (image_version, "solutions-")))
     {
-      g_message ("Not recording network ID as this is not a Solutions system");
+      g_message ("Not recording network ID as it is not required for this image");
       return;
     }
 

--- a/src/eos-metrics-instrumentation.c
+++ b/src/eos-metrics-instrumentation.c
@@ -893,7 +893,10 @@ record_network_id_impl (const char *image_version,
   guint32 network_id;
 
   /* Network ID is only needed for analysis on Solutions images */
-  if (!image_version || !g_str_has_prefix (image_version, "solutions-"))
+  if (!image_version ||
+      !(g_str_has_prefix (image_version, "fnde-") ||
+        g_str_has_prefix (image_version, "impact-") ||
+        g_str_has_prefix (image_version, "solutions-")))
     {
       g_message ("Not recording network ID as this is not a Solutions system");
       return;


### PR DESCRIPTION
We only record the network ID on Solutions images and this category
should include image names starting with 'impact' and 'fnde'. Hardcoding
for the time being until we find a better solution.

https://phabricator.endlessm.com/T27819