### PR TITLE
Fix double free in /proc/cmdline error path

### DIFF
--- a/src/eos-metrics-instrumentation.c
+++ b/src/eos-metrics-instrumentation.c
@@ -266,7 +266,6 @@ check_cmdline (gboolean *is_live_boot,
   if (!g_file_get_contents (KERNEL_CMDLINE_PATH, &cmdline, NULL, &error))
     {
       g_warning ("Error reading " KERNEL_CMDLINE_PATH ": %s", error->message);
-      g_error_free (error);
     }
   else if (g_regex_match_simple (LIVE_BOOT_FLAG_REGEX, cmdline, 0, 0))
     {


### PR DESCRIPTION
The 'error' variable is declared as g_autoptr(GError), meaning that if
it is non-NULL when it goes out of scope, g_error_free() will be called
on it. On the error path, we currently explicitly call g_error_free(),
and do not clear 'error' after doing so. This is a double-free.

Fortunately, reading /proc/cmdline never fails. Nonetheless, delete the
offending line.