### PR TITLE
Ignore empty location label keys

### DIFF
--- a/src/Makefile.am.inc
+++ b/src/Makefile.am.inc
@@ -33,6 +33,8 @@ src_eos_metrics_instrumentation_SOURCES = \
 	src/eins-hwinfo.c \
 	src/eins-location.h \
 	src/eins-location.c \
+	src/eins-location-label.h \
+	src/eins-location-label.c \
 	src/eins-network-id.h \
 	src/eins-network-id.c \
 	src/eins-persistent-tally.h \

--- a/src/eins-location-label.c
+++ b/src/eins-location-label.c
@@ -41,7 +41,6 @@ build_location_label_event (GKeyFile *kf)
   if (keys == NULL || *keys == NULL)
     return NULL;
 
-  g_autoptr (GString) label = g_string_new ("");
   g_auto (GVariantBuilder) builder = G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_ARRAY);
   for (GStrv cur = keys; *cur != NULL; cur++)
     {
@@ -51,14 +50,9 @@ build_location_label_event (GKeyFile *kf)
       if (val == NULL)
         continue;
 
-      if (cur != keys)
-        g_string_append (label, ", ");
-
       g_variant_builder_add (&builder, "{ss}", key, val);
-      g_string_append_printf (label, "\"%s\" = \"%s\"", key, val);
     }
 
-  g_message ("Recording location label: %s", label->str);
   return g_variant_builder_end (&builder);
 }
 
@@ -82,6 +76,8 @@ record_location_label (gpointer unused)
   GVariant *payload = build_location_label_event (kf);
   if (payload != NULL)
     {
+      g_autofree gchar *label = g_variant_print (payload, FALSE /* type_annotate */);
+      g_message ("Recording location label: %s", label);
       emtr_event_recorder_record_event (emtr_event_recorder_get_default (),
                                         LOCATION_LABEL_EVENT,
                                         payload);

--- a/src/eins-location-label.c
+++ b/src/eins-location-label.c
@@ -42,16 +42,21 @@ build_location_label_event (GKeyFile *kf)
     return NULL;
 
   g_auto (GVariantBuilder) builder = G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_ARRAY);
+  gboolean seen_nonempty_value = FALSE;
   for (GStrv cur = keys; *cur != NULL; cur++)
     {
       const gchar *key = *cur;
       g_autofree gchar *val = g_key_file_get_string (kf, LOCATION_LABEL_GROUP, key, NULL);
 
-      if (val == NULL)
+      if (val == NULL || *val == '\0')
         continue;
 
+      seen_nonempty_value = TRUE;
       g_variant_builder_add (&builder, "{ss}", key, val);
     }
+
+  if (!seen_nonempty_value)
+    return NULL;
 
   return g_variant_builder_end (&builder);
 }

--- a/src/eins-location-label.c
+++ b/src/eins-location-label.c
@@ -1,0 +1,115 @@
+/* Copyright 2017–2020 Endless Mobile, Inc. */
+
+/* This file is part of eos-metrics-instrumentation.
+ *
+ * eos-metrics-instrumentation is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * eos-metrics-instrumentation is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with eos-metrics-instrumentation.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include <eosmetrics/eosmetrics.h>
+
+#include "eins-location-label.h"
+
+/*
+ * Recorded at startup and whenever location.conf is modified. The auxiliary
+ * payload is a dictionary of string keys (such as facility, city and state)
+ * to the values provided in the location.conf file. The intention is to allow
+ * an operator to provide an optional human-readable label for the location of
+ * the system, which can be used when preparing reports or visualisations of the
+ * metrics data.
+ */
+#define LOCATION_LABEL_EVENT "eb0302d8-62e7-274b-365f-cd4e59103983"
+
+#define LOCATION_CONF_FILE SYSCONFDIR "/metrics/location.conf"
+#define LOCATION_LABEL_GROUP "Label"
+
+gboolean
+record_location_label (gpointer unused)
+{
+  g_autoptr (GError) err = NULL;
+  g_autoptr (GKeyFile) kf = g_key_file_new ();
+
+  if (!g_key_file_load_from_file (kf, LOCATION_CONF_FILE, G_KEY_FILE_NONE, &err))
+    {
+      /* this file’s existence is optional, so not found is not an error */
+      if (g_error_matches (err, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_NOT_FOUND))
+        return G_SOURCE_REMOVE;
+
+      g_warning ("Failed to load " LOCATION_CONF_FILE ", unable to record location label: %s",
+                 err->message);
+      return G_SOURCE_REMOVE;
+    }
+
+  g_auto (GStrv) keys = g_key_file_get_keys (kf, LOCATION_LABEL_GROUP, NULL, NULL);
+  if (keys == NULL || *keys == NULL)
+    return G_SOURCE_REMOVE;
+
+  g_autoptr (GString) label = g_string_new ("");
+  g_auto (GVariantBuilder) builder = G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_ARRAY);
+  for (GStrv cur = keys; *cur != NULL; cur++)
+    {
+      const gchar *key = *cur;
+      g_autofree gchar *val = g_key_file_get_string (kf, LOCATION_LABEL_GROUP, key, NULL);
+
+      if (val == NULL)
+        continue;
+
+      if (cur != keys)
+        g_string_append (label, ", ");
+
+      g_variant_builder_add (&builder, "{ss}", key, val);
+      g_string_append_printf (label, "\"%s\" = \"%s\"", key, val);
+    }
+
+  g_message ("Recording location label: %s", label->str);
+
+  emtr_event_recorder_record_event (emtr_event_recorder_get_default (),
+                                    LOCATION_LABEL_EVENT,
+                                    g_variant_builder_end (&builder));
+
+  return G_SOURCE_REMOVE;
+}
+
+static void
+on_location_file_changed (GFileMonitor *monitor,
+                          GFile *file,
+                          GFile *other_file,
+                          GFileMonitorEvent event_type,
+                          gpointer user_data)
+{
+  if (event_type == G_FILE_MONITOR_EVENT_CHANGES_DONE_HINT)
+    record_location_label (NULL);
+}
+
+GFileMonitor *
+location_file_monitor_new (void)
+{
+  g_autoptr (GFile) file = g_file_new_for_path (LOCATION_CONF_FILE);
+  g_autoptr (GError) err = NULL;
+  g_autoptr (GFileMonitor) monitor = g_file_monitor_file (file, G_FILE_MONITOR_NONE,
+                                                          NULL, &err);
+
+  if (err != NULL)
+    {
+      g_warning ("Couldn't set up file monitor for " LOCATION_CONF_FILE ": %s",
+                 err->message);
+      return NULL;
+    }
+
+  g_signal_connect (monitor, "changed", G_CALLBACK (on_location_file_changed),
+                    NULL);
+
+  return g_steal_pointer (&monitor);
+}
+

--- a/src/eins-location-label.h
+++ b/src/eins-location-label.h
@@ -1,0 +1,28 @@
+/* Copyright 2017–2020 Endless Mobile, Inc. */
+
+/* This file is part of eos-metrics-instrumentation.
+ *
+ * eos-metrics-instrumentation is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * eos-metrics-instrumentation is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with eos-metrics-instrumentation.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EINS_LOCATION_LABEL_H
+#define EINS_LOCATION_LABEL_H
+
+#include <gio/gio.h>
+
+gboolean record_location_label (gpointer unused);
+GFileMonitor *location_file_monitor_new (void);
+
+#endif /* EINS_LOCATION_LABEL_H */

--- a/src/eins-location-label.h
+++ b/src/eins-location-label.h
@@ -22,6 +22,7 @@
 
 #include <gio/gio.h>
 
+GVariant *build_location_label_event (GKeyFile *kf);
 gboolean record_location_label (gpointer unused);
 GFileMonitor *location_file_monitor_new (void);
 

--- a/src/eos-metrics-instrumentation.c
+++ b/src/eos-metrics-instrumentation.c
@@ -28,6 +28,7 @@
 
 #include "eins-hwinfo.h"
 #include "eins-location.h"
+#include "eins-location-label.h"
 #include "eins-network-id.h"
 #include "eins-persistent-tally.h"
 
@@ -65,16 +66,6 @@
 #define USER_IS_LOGGED_IN "add052be-7b2a-4959-81a5-a7f45062ee98"
 
 #define MIN_HUMAN_USER_ID 1000
-
-/*
- * Recorded at startup and whenever location.conf is modified. The auxiliary
- * payload is a dictionary of string keys (such as facility, city and state)
- * to the values provided in the location.conf file. The intention is to allow
- * an operator to provide an optional human-readable label for the location of
- * the system, which can be used when preparing reports or visualisations of the
- * metrics data.
- */
-#define LOCATION_LABEL_EVENT "eb0302d8-62e7-274b-365f-cd4e59103983"
 
 /*
  * Recorded when we detect a change in the default route after the network
@@ -768,88 +759,6 @@ login_dbus_proxy_new (void)
   g_variant_unref (sessions);
 
   return dbus_proxy;
-}
-
-#define LOCATION_CONF_FILE SYSCONFDIR "/metrics/location.conf"
-#define LOCATION_LABEL_GROUP "Label"
-
-static gboolean
-record_location_label (gpointer unused)
-{
-  g_autoptr (GError) err = NULL;
-  g_autoptr (GKeyFile) kf = g_key_file_new ();
-
-  if (!g_key_file_load_from_file (kf, LOCATION_CONF_FILE, G_KEY_FILE_NONE, &err))
-    {
-      /* this file’s existence is optional, so not found is not an error */
-      if (g_error_matches (err, G_KEY_FILE_ERROR, G_KEY_FILE_ERROR_NOT_FOUND))
-        return G_SOURCE_REMOVE;
-
-      g_warning ("Failed to load " LOCATION_CONF_FILE ", unable to record location label: %s",
-                 err->message);
-      return G_SOURCE_REMOVE;
-    }
-
-  g_auto (GStrv) keys = g_key_file_get_keys (kf, LOCATION_LABEL_GROUP, NULL, NULL);
-  if (keys == NULL || *keys == NULL)
-    return G_SOURCE_REMOVE;
-
-  g_autoptr (GString) label = g_string_new ("");
-  g_auto (GVariantBuilder) builder = G_VARIANT_BUILDER_INIT (G_VARIANT_TYPE_ARRAY);
-  for (GStrv cur = keys; *cur != NULL; cur++)
-    {
-      const gchar *key = *cur;
-      g_autofree gchar *val = g_key_file_get_string (kf, LOCATION_LABEL_GROUP, key, NULL);
-
-      if (val == NULL)
-        continue;
-
-      if (cur != keys)
-        g_string_append (label, ", ");
-
-      g_variant_builder_add (&builder, "{ss}", key, val);
-      g_string_append_printf (label, "\"%s\" = \"%s\"", key, val);
-    }
-
-  g_message ("Recording location label: %s", label->str);
-
-  emtr_event_recorder_record_event (emtr_event_recorder_get_default (),
-                                    LOCATION_LABEL_EVENT,
-                                    g_variant_builder_end (&builder));
-
-  return G_SOURCE_REMOVE;
-}
-
-static void
-on_location_file_changed (GFileMonitor *monitor,
-                          GFile *file,
-                          GFile *other_file,
-                          GFileMonitorEvent event_type,
-                          gpointer user_data)
-{
-  if (event_type == G_FILE_MONITOR_EVENT_CHANGES_DONE_HINT)
-    record_location_label (NULL);
-}
-
-static GFileMonitor *
-location_file_monitor_new (void)
-{
-  g_autoptr (GFile) file = g_file_new_for_path (LOCATION_CONF_FILE);
-  g_autoptr (GError) err = NULL;
-  g_autoptr (GFileMonitor) monitor = g_file_monitor_file (file, G_FILE_MONITOR_NONE,
-                                                          NULL, &err);
-
-  if (err != NULL)
-    {
-      g_warning ("Couldn't set up file monitor for " LOCATION_CONF_FILE ": %s",
-                 err->message);
-      return NULL;
-    }
-
-  g_signal_connect (monitor, "changed", G_CALLBACK (on_location_file_changed),
-                    NULL);
-
-  return g_steal_pointer (&monitor);
 }
 
 static void

--- a/tests/Makefile.am.inc
+++ b/tests/Makefile.am.inc
@@ -18,6 +18,7 @@
 
 noinst_PROGRAMS += \
 	tests/test-hwinfo \
+	tests/test-location-label \
 	tests/test-location \
 	tests/test-persistent-tally \
 	$(NULL)
@@ -26,6 +27,7 @@ TESTS = \
 	tests/test-hwinfo \
 	tests/test-persistent-tally \
 	tests/test-location.py \
+	tests/test-location-label \
 	run_coverage.coverage \
 	$(NULL)
 TEST_EXTENSIONS = .py .coverage
@@ -68,5 +70,17 @@ tests_test_location_CPPFLAGS = $(TEST_FLAGS)
 tests_test_location_LDADD = $(TEST_LIBS)
 
 EXTRA_DIST += tests/test-location.py
+
+tests_test_location_label_SOURCES = \
+	src/eins-location-label.h \
+	src/eins-location-label.c \
+	tests/test-location-label.c \
+	$(NULL)
+
+tests_test_location_label_CPPFLAGS = $(TEST_FLAGS) \
+	-DSYSCONFDIR="\"$(sysconfdir)\"" \
+	$(NULL)
+
+tests_test_location_label_LDADD = $(TEST_LIBS)
 
 clean-local:: clean-coverage

--- a/tests/test-location-label.c
+++ b/tests/test-location-label.c
@@ -1,0 +1,77 @@
+/* Copyright 2020 Endless Mobile, Inc. */
+
+/* This file is part of eos-metrics-instrumentation.
+ *
+ * eos-metrics-instrumentation is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or (at your
+ * option) any later version.
+ *
+ * eos-metrics-instrumentation is distributed in the hope that it will be
+ * useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+ * Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with eos-metrics-instrumentation.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+
+#include "eins-location-label.h"
+
+static void
+test_empty_keyfile (void)
+{
+  g_autoptr(GKeyFile) kf = g_key_file_new ();
+  g_autoptr(GVariant) payload = build_location_label_event (kf);
+
+  g_assert_null (payload);
+}
+
+static void
+test_empty_group (void)
+{
+  g_autoptr(GKeyFile) kf = g_key_file_new ();
+  gboolean ret = g_key_file_load_from_data (kf, "[Label]\n", -1, G_KEY_FILE_NONE, NULL);
+  g_assert_true (ret);
+
+  g_autoptr(GVariant) payload = build_location_label_event (kf);
+  g_assert_null (payload);
+}
+
+static void
+test_only_populated_keys (void)
+{
+  g_autoptr(GKeyFile) kf = g_key_file_new ();
+  g_key_file_set_string (kf, "Label", "facility", "Aperture Science");
+  g_key_file_set_string (kf, "Label", "city", "Unknown");
+
+  g_autoptr(GVariant) payload = build_location_label_event (kf);
+  g_assert_nonnull (payload);
+
+  g_assert_cmpuint (g_variant_n_children (payload), ==, 2);
+
+  const gchar *value;
+  gboolean ret;
+
+  ret = g_variant_lookup (payload, "facility", "&s", &value);
+  g_assert_true (ret);
+  g_assert_cmpstr (value, ==, "Aperture Science");
+
+  ret = g_variant_lookup (payload, "city", "&s", &value);
+  g_assert_true (ret);
+  g_assert_cmpstr (value, ==, "Unknown");
+}
+
+int
+main (int   argc,
+      char *argv[])
+{
+  g_test_init (&argc, &argv, NULL);
+
+  g_test_add_func ("/location-label/empty", test_empty_keyfile);
+  g_test_add_func ("/location-label/empty-group", test_empty_group);
+  g_test_add_func ("/location-label/only-populated-keys", test_only_populated_keys);
+
+  return g_test_run ();
+}


### PR DESCRIPTION
If you use eos-label-location and don't give an answer to one or more of
its questions, you get a file like this:

    [Label]
    facility = Will's House
    city = London
    state =

The 'site' page in our branch of gnome-initial-setup similarly writes
empty files like this:

    [Label]
    id =
    city =
    state =
    street =
    country =
    facility =

As a result of this second case, over 99% of the rows in our production
table for this event are:

    {"id": "", "city": "", "state": "", "street": "", "country": "", "facility": ""}

Handle the first case by ignoring empty fields. Handle the second case
by not reporting a metric if there are no non-empty fields. Test these
cases.

https://phabricator.endlessm.com/T30469
