### PR TITLE
Drop geoclue-2.0 dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,6 @@ Maintainer: Kurt von Laven <kurt@endlessm.com>
 Build-Depends: debhelper (>= 9),
 	autotools-dev,
 	eos-metrics-0-dev (>= 0.3.0),
-	geoclue-2.0,
 	libflatpak-dev,
 	libglib2.0-dev,
 	libgtop2-dev,
@@ -20,7 +19,6 @@ Package: eos-metrics-instrumentation
 Section: misc
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends},
-	geoclue-2.0,
 	systemd (>= 200),
 	util-linux (>= 2.32),
 Description: Metrics instrumentation for EndlessOS


### PR DESCRIPTION
Since EOS is going to remove (Geo)location events, geoclue-2.0 will not
be used anymore and the dependency should be dropped.

https://phabricator.endlessm.com/T31354