### PR TITLE
hwinfo: Implement combined computer hardware info event

### DIFF
--- a/src/eins-hwinfo.c
+++ b/src/eins-hwinfo.c
@@ -24,11 +24,36 @@
 #include <json-glib/json-glib.h>
 
 /*
- * Reported at system startup, and every RECORD_DISK_SPACE_INTERVAL_SECONDS
- * after startup. The payload is a triple of uint32, (uuu), representing the
- * the total size, space used, and space available on the root filesystem,
- * measured in gibibytes (2^30 bytes). We round to the nearest gibibyte: we
- * have no need of a precise figure in the reported data.
+ * Computer hardware information event with payload "(uuuua(sqd))".
+ *
+ * Field  | Description
+ * -------+----------------------------------
+ *      u | Please see RAM section
+ *    uuu | Please see Root partition section
+ * a(sqd) | Please see CPU section
+ */
+
+#define COMPUTER_HWINFO_EVENT "81f303aa-448d-443d-97f9-8d8a9169321c"
+
+/* 24 hours */
+#define RECORD_COMPUTER_HWINFO_INTERVAL_SECONDS (60u * 60u * 24u)
+
+/*
+ * RAM:
+ * The amount of physical memory accessible to Endless OS, in mebibytes (2^20
+ * bytes). The payload is a uint32 (u).
+ */
+
+#define ONE_MIB_IN_BYTES (G_GUINT64_CONSTANT (1024 * 1024))
+
+#define RAMINFO_TYPE_STRING "u"
+
+/*
+ * Root partition:
+ * The payload is a triple of uint32, (uuu), representing the the total size,
+ * space used, and space available on the root filesystem, measured in gibibytes
+ * (2^30 bytes). We round to the nearest gibibyte: we have no need of a precise
+ * figure in the reported data.
  *
  * On dual-boot installations, this refers to the Endless OS image file, not
  * the Windows partition it is hosted on.
@@ -40,36 +65,16 @@
  * could derive the third. That's not the case: typically, 5% of space is
  * reserved (so used + available = 0.95 * total) but this is a tunable
  * parameter of the filesystem.
- *
- * If disk space cannot be determined for some reason, this event will not be
- * reported.
  */
-#define SYSROOT_DISK_SPACE_EVENT "5f58024f-3b99-47d3-a17f-1ec876acd97e"
-
-/* One day */
-#define RECORD_DISK_SPACE_INTERVAL_SECONDS (60u * 60u * 24u)
-
-/* The presence of this file indicates that the first-boot resize of the root
- * filesystem is complete.
- *
- * https://github.com/endlessm/eos-boot-helper/blob/master/eos-firstboot
- */
-#define BOOTED_FLAG_FILE_PATH "/var/eos-booted"
 
 #define ONE_GIB_IN_BYTES (G_GUINT64_CONSTANT (1024 * 1024 * 1024))
 
-/*
- * The amount of physical memory accessible to Endless OS, in mebibytes (2^20
- * bytes). Reported once at system startup. The payload is a uint32 (u).
- */
-#define RAM_SIZE_EVENT "aee94585-07a2-4483-a090-25abda650b12"
-
-#define ONE_MIB_IN_BYTES (G_GUINT64_CONSTANT (1024 * 1024))
+#define ROOTFS_SPACE_TYPE_STRING "uuu"
 
 /*
- * CPUs in the system. Reported once at system startup. The payload is an array
- * of triples -- a(sqd) -- containing the following information for each group
- * of similar cores/threads:
+ * CPU:
+ * CPUs in the system. The payload is an array of triples -- a(sqd) --
+ * containing the following information for each group of similar cores/threads:
  *
  * Field | Type   | Description              | Default if unknown
  * ------+--------+--------------------------+-------------------
@@ -91,7 +96,12 @@
  * array, containing details of the big and LITTLE cores. In practice, the
  * current implementation only reports the currently-active cores.
  */
-#define CPU_MODELS_EVENT "4a75488a-0d9a-4c38-8556-148f500edaf0"
+
+#define CPUINFO_TYPE_STRING "(sqd)"
+#define CPUINFO_ARRAY_TYPE_STRING "a" CPUINFO_TYPE_STRING
+
+#define COMPUTER_HWINFO_TYPE_STRING "(" RAMINFO_TYPE_STRING \
+  ROOTFS_SPACE_TYPE_STRING "@" CPUINFO_ARRAY_TYPE_STRING ")"
 
 static guint32
 round_to_nearest (guint64 size,
@@ -105,14 +115,32 @@ round_to_nearest (guint64 size,
   return (guint32) CLAMP (size / divisor, 0, G_MAXUINT32);
 }
 
-GVariant *
-eins_hwinfo_get_disk_space_for_partition (GFile   *file,
-                                          GError **error)
+guint32
+eins_hwinfo_get_ram_size (void)
+{
+  glibtop_mem mem;
+  guint32 size_mib;
+
+  glibtop_get_mem (&mem);
+  size_mib = round_to_nearest (mem.total, ONE_MIB_IN_BYTES);
+  return size_mib;
+}
+
+gboolean
+eins_hwinfo_get_disk_space_for_partition (GFile          *file,
+                                          DiskSpaceType  *diskspace,
+                                          GError        **error)
 {
   g_autoptr(GFileInfo) info = NULL;
   guint64 total = 0;
   guint64 used = 0;
-  guint64 available = 0;
+  guint64 free = 0;
+
+  g_return_val_if_fail (diskspace != NULL, FALSE);
+
+  diskspace->total = 0;
+  diskspace->used = 0;
+  diskspace->free = 0;
 
   info = g_file_query_filesystem_info (file,
                                        G_FILE_ATTRIBUTE_FILESYSTEM_SIZE ","
@@ -121,143 +149,32 @@ eins_hwinfo_get_disk_space_for_partition (GFile   *file,
                                        NULL /* cancellable */,
                                        error);
   if (info == NULL)
-    {
-      /* TODO: g_file_peek_path() from GLib 2.56. */
-      g_autofree gchar *path = g_file_get_path (file);
-      g_prefix_error (error, "Couldn't get disk space for %s: ", path);
-      return NULL;
-    }
+    return FALSE;
 
   total = g_file_info_get_attribute_uint64 (info,
                                             G_FILE_ATTRIBUTE_FILESYSTEM_SIZE);
   used = g_file_info_get_attribute_uint64 (info,
                                            G_FILE_ATTRIBUTE_FILESYSTEM_USED);
-  available = g_file_info_get_attribute_uint64 (info,
-                                                G_FILE_ATTRIBUTE_FILESYSTEM_FREE);
+  free = g_file_info_get_attribute_uint64 (info,
+                                           G_FILE_ATTRIBUTE_FILESYSTEM_FREE);
 
-  return g_variant_new ("(uuu)",
-                        round_to_nearest (total, ONE_GIB_IN_BYTES),
-                        round_to_nearest (used, ONE_GIB_IN_BYTES),
-                        round_to_nearest (available, ONE_GIB_IN_BYTES));
-}
+  diskspace->total = round_to_nearest (total, ONE_GIB_IN_BYTES);
+  diskspace->used = round_to_nearest (used, ONE_GIB_IN_BYTES);
+  diskspace->free = round_to_nearest (free, ONE_GIB_IN_BYTES);
 
-static gboolean
-is_mounted (GFile *file)
-{
-  g_autoptr(GFileInfo) info = g_file_query_info (file,
-                                                 G_FILE_ATTRIBUTE_UNIX_IS_MOUNTPOINT,
-                                                 G_FILE_QUERY_INFO_NOFOLLOW_SYMLINKS,
-                                                 NULL, NULL);
-
-  return info != NULL &&
-    g_file_info_get_attribute_boolean (info, G_FILE_ATTRIBUTE_UNIX_IS_MOUNTPOINT);
+  return TRUE;
 }
 
 static void
-record_disk_space_for (GFile       *file,
-                       const gchar *event_uuid)
-{
-  GVariant *payload;
-  g_autoptr(GError) error = NULL;
-
-  payload = eins_hwinfo_get_disk_space_for_partition (file, &error);
-  if (payload == NULL)
-    g_warning ("%s", error->message);
-  else
-    emtr_event_recorder_record_event (emtr_event_recorder_get_default (),
-                                      event_uuid,
-                                      g_steal_pointer (&payload));
-}
-
-static gboolean
-record_disk_space (gpointer unused)
+eins_hwinfo_get_space_for_rootfs (DiskSpaceType *diskspace)
 {
   g_autoptr(GFile) root = g_file_new_for_path ("/");
-
-  record_disk_space_for (root, SYSROOT_DISK_SPACE_EVENT);
-
-  return G_SOURCE_CONTINUE;
-}
-
-static void
-start_recording_disk_space (void)
-{
-  record_disk_space (NULL);
-  g_timeout_add_seconds (RECORD_DISK_SPACE_INTERVAL_SECONDS, record_disk_space,
-                         NULL);
-}
-
-static void
-boot_finished_cb (GFileMonitor     *monitor,
-                  GFile            *booted,
-                  GFile            *other_file,
-                  GFileMonitorEvent event_type,
-                  gpointer          user_data)
-{
-  /* Any event will do */
-  g_debug ("got (GFileMonitorEvent) %d for %s", event_type, BOOTED_FLAG_FILE_PATH);
-  start_recording_disk_space ();
-
-  g_signal_handlers_disconnect_by_func (monitor, boot_finished_cb, NULL);
-  g_object_unref (monitor);
-}
-
-/* On the first boot, the root partition is extended to fill the disk, in the
- * background. We may be running before this process has completed; in that
- * case, we need to wait. Rather than monitoring eos-firstboot.service via
- * systemd's D-Bus API, we look for a flag file in /var.
- */
-static gboolean
-start_recording_disk_space_when_booted (gpointer data)
-{
-  g_autoptr(GFile) booted = g_file_new_for_path (BOOTED_FLAG_FILE_PATH);
-  g_autoptr(GFileMonitor) monitor = NULL;
   g_autoptr(GError) error = NULL;
 
-  if (g_file_query_exists (booted, NULL))
-    {
-      g_debug ("%s already exists", BOOTED_FLAG_FILE_PATH);
-      start_recording_disk_space ();
-    }
-  else if (!(monitor = g_file_monitor_file (booted, G_FILE_MONITOR_NONE,
-                                            NULL, &error)))
-    {
-      g_warning ("Couldn't watch %s: %s",
-                 BOOTED_FLAG_FILE_PATH, error->message);
-      start_recording_disk_space ();
-    }
-  else
-    {
-      g_debug ("Waiting for %s to appear before reporting disk space",
-               BOOTED_FLAG_FILE_PATH);
-
-      /* Ownership is transferred to boot_finished_cb() */
-      g_signal_connect (g_steal_pointer (&monitor), "changed",
-                        (GCallback) boot_finished_cb,
-                        NULL);
-    }
-
-  return G_SOURCE_REMOVE;
-}
-
-GVariant *
-eins_hwinfo_get_ram_size (void)
-{
-  glibtop_mem mem;
-  guint32 size_mib;
-
-  glibtop_get_mem (&mem);
-  size_mib = round_to_nearest (mem.total, ONE_MIB_IN_BYTES);
-  return g_variant_new_uint32 (size_mib);
-}
-
-static gboolean
-record_ram_size (gpointer unused)
-{
-  emtr_event_recorder_record_event (emtr_event_recorder_get_default (),
-                                    RAM_SIZE_EVENT,
-                                    eins_hwinfo_get_ram_size ());
-  return G_SOURCE_REMOVE;
+  if (!eins_hwinfo_get_disk_space_for_partition (root, diskspace, &error))
+    g_warning ("Couldn't get disk space for %s: %s",
+               g_file_peek_path (root),
+               error->message);
 }
 
 typedef struct _LscpuFieldType {
@@ -421,7 +338,7 @@ eins_hwinfo_parse_lscpu_json (const gchar *json_data,
    * big.LITTLE device separately, so wrap this one element in an array to
    * allow the same event ID to be used in future.
    */
-  return g_variant_new_array (NULL, &payload, 1);
+  return g_variant_new_array (G_VARIANT_TYPE(CPUINFO_TYPE_STRING), &payload, 1);
 }
 
 GVariant *
@@ -446,7 +363,7 @@ eins_hwinfo_get_cpu_info (void)
       || !g_subprocess_wait_check (lscpu, NULL /* cancellable */, &error))
     {
       g_warning ("error running lscpu: %s", error->message);
-      return NULL;
+      return g_variant_new_array (G_VARIANT_TYPE(CPUINFO_TYPE_STRING), NULL, 0);
     }
 
   json_data = g_bytes_get_data (lscpu_stdout, &json_size);
@@ -454,22 +371,107 @@ eins_hwinfo_get_cpu_info (void)
   return eins_hwinfo_parse_lscpu_json (json_data, (gssize) json_size);
 }
 
-static gboolean
-record_cpu_models (gpointer unused)
+GVariant *
+eins_hwinfo_get_computer_hwinfo (void)
 {
-  GVariant *payload = eins_hwinfo_get_cpu_info ();
+  guint32 ramsize = eins_hwinfo_get_ram_size ();
+  DiskSpaceType diskspace = {};
+  GVariant *cpuinfo = eins_hwinfo_get_cpu_info();
+
+  eins_hwinfo_get_space_for_rootfs (&diskspace);
+
+  return g_variant_new (COMPUTER_HWINFO_TYPE_STRING, ramsize,
+                        diskspace.total, diskspace.used, diskspace.free,
+                        cpuinfo);
+}
+
+static gboolean
+record_computer_hwinfo (gpointer unused)
+{
+  GVariant *payload = eins_hwinfo_get_computer_hwinfo ();
 
   if (payload != NULL)
     emtr_event_recorder_record_event (emtr_event_recorder_get_default (),
-                                      CPU_MODELS_EVENT,
+                                      COMPUTER_HWINFO_EVENT,
                                       g_steal_pointer (&payload));
+  return G_SOURCE_CONTINUE;
+}
+
+static void
+start_recording_record_computer_hwinfo (void)
+{
+  record_computer_hwinfo (NULL);
+
+  /* Record the computer hardware info every 24 hours. */
+  g_timeout_add_seconds (RECORD_COMPUTER_HWINFO_INTERVAL_SECONDS,
+                         record_computer_hwinfo,
+                         NULL);
+}
+
+/* The presence of this file indicates that the first-boot resize of the root
+ * filesystem is complete.
+ *
+ * https://github.com/endlessm/eos-boot-helper/blob/master/eos-firstboot
+ */
+
+#define BOOTED_FLAG_FILE_PATH "/var/eos-booted"
+
+static void
+boot_finished_cb (GFileMonitor     *monitor,
+                  GFile            *booted,
+                  GFile            *other_file,
+                  GFileMonitorEvent event_type,
+                  gpointer          user_data)
+{
+  /* Any event will do */
+  g_debug ("got (GFileMonitorEvent) %d for %s", event_type, BOOTED_FLAG_FILE_PATH);
+  start_recording_record_computer_hwinfo ();
+
+  g_signal_handlers_disconnect_by_func (monitor, boot_finished_cb, NULL);
+  g_object_unref (monitor);
+}
+
+/* On the first boot, the root partition is extended to fill the disk, in the
+ * background. We may be running before this process has completed; in that
+ * case, we need to wait. Rather than monitoring eos-firstboot.service via
+ * systemd's D-Bus API, we look for a flag file in /var.
+ */
+
+static gboolean
+start_recording_computer_info_when_booted (gpointer data)
+{
+  g_autoptr(GFile) booted = g_file_new_for_path (BOOTED_FLAG_FILE_PATH);
+  g_autoptr(GFileMonitor) monitor = NULL;
+  g_autoptr(GError) error = NULL;
+
+  if (g_file_query_exists (booted, NULL))
+    {
+      g_debug ("%s already exists", BOOTED_FLAG_FILE_PATH);
+      start_recording_record_computer_hwinfo ();
+    }
+  else if (!(monitor = g_file_monitor_file (booted, G_FILE_MONITOR_NONE,
+                                            NULL, &error)))
+    {
+      g_warning ("Couldn't watch %s: %s",
+                 BOOTED_FLAG_FILE_PATH, error->message);
+      start_recording_record_computer_hwinfo ();
+    }
+  else
+    {
+      g_debug ("Waiting for %s to appear before reporting disk space",
+               BOOTED_FLAG_FILE_PATH);
+
+      /* Ownership is transferred to boot_finished_cb() */
+      g_signal_connect (g_steal_pointer (&monitor), "changed",
+                        (GCallback) boot_finished_cb,
+                        NULL);
+    }
+
   return G_SOURCE_REMOVE;
 }
 
 void
 eins_hwinfo_start (void)
 {
-  g_idle_add (start_recording_disk_space_when_booted, NULL);
-  g_idle_add (record_ram_size, NULL);
-  g_idle_add (record_cpu_models, NULL);
+  g_idle_add (start_recording_computer_info_when_booted, NULL);
 }

--- a/src/eins-hwinfo.h
+++ b/src/eins-hwinfo.h
@@ -24,10 +24,20 @@
 void eins_hwinfo_start (void);
 
 /* For tests */
-GVariant *eins_hwinfo_get_disk_space_for_partition (GFile   *file,
-                                                    GError **error);
-GVariant *eins_hwinfo_get_ram_size (void);
+typedef struct _DiskSpaceType {
+  guint32 total;
+  guint32 used;
+  guint32 free;
+} DiskSpaceType;
+
+gboolean eins_hwinfo_get_disk_space_for_partition (GFile          *file,
+                                                   DiskSpaceType  *diskspace,
+                                                   GError        **error);
+
+guint32 eins_hwinfo_get_ram_size (void);
 
 GVariant *eins_hwinfo_get_cpu_info (void);
 GVariant *eins_hwinfo_parse_lscpu_json (const gchar *json_data,
                                         gssize       json_size);
+
+GVariant *eins_hwinfo_get_computer_hwinfo (void);


### PR DESCRIPTION
Introduce new COMPUTER_HWINFO_EVENT to replace/merge RAM_SIZE_EVENT,
SYSROOT_DISK_SPACE_EVENT and CPU_MODELS_EVENT. Modified corresponding
test plans as well.

https://phabricator.endlessm.com/T32205