### PR TITLE
Correctly stop session timers

### DIFF
--- a/src/eos-metrics-instrumentation.c
+++ b/src/eos-metrics-instrumentation.c
@@ -277,7 +277,7 @@ main (gint  argc,
       exit (1);
     }
 
-  session_by_user_id = g_hash_table_new (NULL, NULL);
+  session_by_user_id = g_hash_table_new_full (NULL, NULL, NULL, g_object_unref);
 
   GDBusProxy *systemd_dbus_proxy = systemd_dbus_proxy_new ();
   GDBusProxy *login_dbus_proxy = login_dbus_proxy_new ();

--- a/src/eos-metrics-instrumentation.c
+++ b/src/eos-metrics-instrumentation.c
@@ -174,7 +174,8 @@ static void
 remove_session (guint32 user_id)
 {
   /* The timer will stop itself when its reference count falls to 0. */
-  g_hash_table_remove (session_by_user_id, userid_to_key (user_id));
+  gboolean removed = g_hash_table_remove (session_by_user_id, userid_to_key (user_id));
+  g_assert (removed);
 }
 
 /*

--- a/src/eos-metrics-instrumentation.c
+++ b/src/eos-metrics-instrumentation.c
@@ -277,7 +277,7 @@ main (gint  argc,
       exit (1);
     }
 
-  session_by_user_id = g_hash_table_new (g_direct_hash, g_direct_equal);
+  session_by_user_id = g_hash_table_new (NULL, NULL);
 
   GDBusProxy *systemd_dbus_proxy = systemd_dbus_proxy_new ();
   GDBusProxy *login_dbus_proxy = login_dbus_proxy_new ();


### PR DESCRIPTION
remove_session() claims:

> /* The timer will stop itself when its reference count falls to 0. */

This is technically true, but previously removing the timer from the
hash table did not decrement its refcount. As a result, the timer was
only stopped when eos-metrics-instrumentation exits and falls off the
bus (at which point eos-event-recorder-daemon cleans up its timers).

Fix this, and make some other superficial tweaks.

https://phabricator.endlessm.com/T33295
