### PR TITLE
Fix assertion failure after user logs in

### DIFF
--- a/src/eins-hwinfo.c
+++ b/src/eins-hwinfo.c
@@ -1,4 +1,4 @@
-/* Copyright 2018 Endless Mobile, Inc. */
+/* Copyright 2018 Endless OS Foundation LLC. */
 
 /* This file is part of eos-metrics-instrumentation.
  *

--- a/src/eins-hwinfo.h
+++ b/src/eins-hwinfo.h
@@ -1,4 +1,4 @@
-/* Copyright 2018 Endless Mobile, Inc. */
+/* Copyright 2018 Endless OS Foundation LLC. */
 
 /* This file is part of eos-metrics-instrumentation.
  *

--- a/src/eos-crash-metrics.c
+++ b/src/eos-crash-metrics.c
@@ -1,4 +1,4 @@
-/* Copyright © 2017, 2020 Endless Mobile, Inc.
+/* Copyright © 2017, 2020 Endless OS Foundation LLC.
  *
  * This file is part of eos-metrics-instrumentation.
  *

--- a/src/eos-metrics-instrumentation.c
+++ b/src/eos-metrics-instrumentation.c
@@ -173,6 +173,10 @@ add_session (guint32 user_id)
 static void
 remove_session (guint32 user_id)
 {
+  /*  Only care about real humans */
+  if (user_id < MIN_HUMAN_USER_ID)
+    return;
+
   /* The timer will stop itself when its reference count falls to 0. */
   gboolean removed = g_hash_table_remove (session_by_user_id, userid_to_key (user_id));
   g_assert (removed);

--- a/src/eos-metrics-instrumentation.c
+++ b/src/eos-metrics-instrumentation.c
@@ -1,4 +1,4 @@
-/* Copyright 2014, 2015 Endless Mobile, Inc. */
+/* Copyright 2014, 2015 Endless OS Foundation LLC. */
 
 /* This file is part of eos-metrics-instrumentation.
  *

--- a/src/eos-metrics-instrumentation.c
+++ b/src/eos-metrics-instrumentation.c
@@ -179,7 +179,9 @@ remove_session (guint32 user_id)
 
   /* The timer will stop itself when its reference count falls to 0. */
   gboolean removed = g_hash_table_remove (session_by_user_id, userid_to_key (user_id));
-  g_assert (removed);
+
+  if (!removed)
+    g_warning ("No running timer for user ID %" G_GUINT32_FORMAT, user_id);
 }
 
 /*

--- a/tests/test-hwinfo.c
+++ b/tests/test-hwinfo.c
@@ -1,4 +1,4 @@
-/* Copyright 2018 Endless Mobile, Inc. */
+/* Copyright 2018 Endless OS Foundation LLC. */
 
 /* This file is part of eos-metrics-instrumentation.
  *

--- a/tools/eos-label-location.in
+++ b/tools/eos-label-location.in
@@ -3,7 +3,7 @@
 #
 # eos-label-location: edit the location label for metrics instrumentation
 #
-# Copyright © 2017 Endless Mobile, Inc.
+# Copyright © 2017 Endless OS Foundation LLC.
 # Authors:
 #  Robert McQueen <rob@endlessm.com>
 #


### PR DESCRIPTION
I added an assertion in #104 which turns out to fail and abort the process whenever the GDM greeter quits.

This PR fixes the logic error, softens the assertion to a more detailed warning (rationale in commit message) and updates some © messages.

https://phabricator.endlessm.com/T33295