### PR TITLE
hwinfo: Fix path to record_time file

### DIFF
--- a/src/eins-hwinfo.c
+++ b/src/eins-hwinfo.c
@@ -105,7 +105,7 @@
 #define RECORD_COMPUTER_HWINFO_INTERVAL_USECONDS G_TIME_SPAN_DAY
 
 /* The path of a file to hold next record time. */
-#define RECORD_TIME_FILE_PATH INSTRUMENTATION_CACHE_DIR "record_time"
+#define RECORD_TIME_FILE_PATH INSTRUMENTATION_CACHE_DIR "/record_time"
 
 static gint64
 get_next_record_time (void)


### PR DESCRIPTION
In the Autotools build system (removed in
2751d4a329df06f573cacf455b5fc5801a7cec9a) there was a trailing slash on
INSTRUMENTATION_CACHE_DIR. In the Meson build system (added in
96dab569cfe4c11b6f6a5ae59713c396bfd9e62e) there is not. As a result,
this daemon has been writing to
/var/cache/eos-metrics-instrumentationrecord_time rather than
/var/cache/eos-metrics-instrumentation/record_time.

Fix this by adding a separator when the strings are concatenated.

Because this change has not entered a stable release of Endless OS, I'm
not going to worry about deleting or moving the erroneous file.

https://phabricator.endlessm.com/T33592
