### PR TITLE
Run as metrics user, not root

### DIFF
--- a/data/eos-metrics-instrumentation.service.in
+++ b/data/eos-metrics-instrumentation.service.in
@@ -6,6 +6,7 @@ After=eos-metrics-event-recorder.service
 [Service]
 Type=simple
 ExecStart=@libexecdir@/eos-metrics-instrumentation
+User=metrics
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This applies to the main daemon, not the coredump handler.

I have been running with this change locally for some time and have
noticed no adverse effects. An unprivileged user can receive systemd's
signals about startup finishind and users logging in and out, and
execute `lscpu --json` with no difference in output.

Perhaps in the past there was a reason to run as root, but no longer.

https://phabricator.endlessm.com/T9267
