### PR TITLE
Add meson option to disable crash metrics

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -20,13 +20,15 @@ configure_file(
     install_dir: systemd_dep.get_variable(pkgconfig: 'tmpfilesdir'),
 )
 
-# sysctl configuration
-configure_file(
-    input: '90-eos-crash-metrics.conf.in',
-    output: '90-eos-crash-metrics.conf',
-    configuration: configuration_data({
-        'libexecdir': libexec_dir,
-    }),
-    install: true,
-    install_dir: systemd_dep.get_variable(pkgconfig: 'sysctldir'),
-)
+if get_option('crash_metrics').enabled()
+    # sysctl configuration
+    configure_file(
+        input: '90-eos-crash-metrics.conf.in',
+        output: '90-eos-crash-metrics.conf',
+        configuration: configuration_data({
+            'libexecdir': libexec_dir,
+        }),
+        install: true,
+        install_dir: systemd_dep.get_variable(pkgconfig: 'sysctldir'),
+    )
+endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,5 @@
+option('crash_metrics',
+  type: 'feature',
+  value: 'enabled',
+  description: 'Enable crash metrics, which breaks systemd-coredump'
+)

--- a/src/meson.build
+++ b/src/meson.build
@@ -26,11 +26,13 @@ daemon = executable('eos-metrics-instrumentation',
     install_dir: libexec_dir,
 )
 
-crash_metrics = executable('eos-crash-metrics',
-    dependencies: common_deps,
-    sources: [
-        'eos-crash-metrics.c',
-    ],
-    install: true,
-    install_dir: libexec_dir,
-)
+if get_option('crash_metrics').enabled()
+    crash_metrics = executable('eos-crash-metrics',
+        dependencies: common_deps,
+        sources: [
+            'eos-crash-metrics.c',
+        ],
+        install: true,
+        install_dir: libexec_dir,
+    )
+endif


### PR DESCRIPTION
These metrics conflict with systemd-coredump.

Fixes #111