### PR TITLE
debian: Build-depend on systemd-dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/debian/.debhelper/
+/debian/debhelper-build-stamp
+/debian/eos-metrics-instrumentation.substvars
+/debian/eos-metrics-instrumentation/
+/debian/files

--- a/debian/control
+++ b/debian/control
@@ -13,6 +13,7 @@ Build-Depends:
 	meson,
 	python3-dbus,
 	python3-dbusmock,
+	systemd-dev,
 	util-linux (>= 2.32),
 
 Package: eos-metrics-instrumentation


### PR DESCRIPTION
systemd.pc, which is used to look up the paths to install a systemd unit, tmpfiles.d snippet and sysctl.d snippet, is part of this package.

When we updated systemd in EOS 6, we dropped our patch for the the `systemd` binary package in previous branches which marked it as `Priority: required`, instead leaving it as `Priority: important`. When it was `required`, it would always be present in the buildroot, and so would `systemd-dev` which it (surprisingly!) depends on; but now it is not. 

Explicitly declare this build dependency, as we should have been doing all along.

Also add a `.gitignore`. My bad for removing it in 6eb0bbd but in my defence the version I removed didn't ignore these files.

https://phabricator.endlessm.com/T35070#990194
https://phabricator.endlessm.com/T35352
