### PR TITLE
Backport CPU flags change to eos5.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/debian/.debhelper/
+/debian/debhelper-build-stamp
+/debian/eos-metrics-instrumentation.substvars
+/debian/eos-metrics-instrumentation/
+/debian/files

--- a/debian/control
+++ b/debian/control
@@ -13,6 +13,7 @@ Build-Depends:
 	meson,
 	python3-dbus,
 	python3-dbusmock,
+	systemd-dev,
 	util-linux (>= 2.32),
 
 Package: eos-metrics-instrumentation

--- a/src/eins-hwinfo.c
+++ b/src/eins-hwinfo.c
@@ -79,6 +79,7 @@
  *     0 | string | Human-readable CPU model | ''
  *     1 | uint16 | Number of cores/threads  | 0
  *     2 | double | Maximum¹ speed in MHz    | 0.
+ *     3 | string | CPU instruction extensions flags | ''
  *
  * ¹ If the maximum speed can't be determined, we report the current speed
  *   instead, if known.
@@ -95,7 +96,7 @@
  * current implementation only reports the currently-active cores.
  */
 
-#define CPUINFO_TYPE_STRING "(sqd)"
+#define CPUINFO_TYPE_STRING "(sqds)"
 #define CPUINFO_ARRAY_TYPE_STRING "a" CPUINFO_TYPE_STRING
 
 #define COMPUTER_HWINFO_TYPE_STRING "(" RAMINFO_TYPE_STRING \
@@ -249,6 +250,8 @@ static const LscpuFieldType LSCPU_FIELDS[] = {
   { { "CPU(s):", NULL }, G_VARIANT_TYPE_UINT16, "0" },
   /* From manual testing, CPU max MHz is not know within a VirtualBox VM. */
   { { "CPU max MHz:", "CPU MHz:", NULL }, G_VARIANT_TYPE_DOUBLE, "0" },
+  /* Know what cpu instruction extensions are supported */
+  { { "Flags:", NULL }, NULL, "" },
 };
 static const gsize NUM_LSCPU_FIELDS = G_N_ELEMENTS (LSCPU_FIELDS);
 

--- a/tests/test-hwinfo-data/bad-wrong-data-type.json
+++ b/tests/test-hwinfo-data/bad-wrong-data-type.json
@@ -2,6 +2,7 @@
    "lscpu": [
       {"field": "Model name:", "data": "hello"},
       {"field": "CPU(s):", "data": "3.14"},
-      {"field": "CPU max MHz:", "data": "extremely fast"}
+      {"field": "CPU max MHz:", "data": "extremely fast"},
+      {"field": "Flags:", "data": "hi"}
    ]
 }

--- a/tests/test-hwinfo-data/good-no-cpu-max-mhz.json
+++ b/tests/test-hwinfo-data/good-no-cpu-max-mhz.json
@@ -2,6 +2,7 @@
    "lscpu": [
       {"field": "CPU(s):", "data": "1"},
       {"field": "Model name:", "data": "Intel(R) Core(TM) i7-5500U CPU @ 2.40GHz"},
-      {"field": "CPU MHz:", "data": "2385.484"}
+      {"field": "CPU MHz:", "data": "2385.484"},
+      {"field": "Flags:", "data": "fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb invpcid_single pti tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid rdseed adx smap intel_pt xsaveopt ibpb ibrs stibp dtherm ida arat pln pts"}
    ]
 }

--- a/tests/test-hwinfo-data/good-rpi4b.json
+++ b/tests/test-hwinfo-data/good-rpi4b.json
@@ -1,0 +1,107 @@
+{
+   "lscpu": [
+      {
+         "field": "Architecture:",
+         "data": "aarch64"
+      },{
+         "field": "CPU op-mode(s):",
+         "data": "32-bit, 64-bit"
+      },{
+         "field": "Byte Order:",
+         "data": "Little Endian"
+      },{
+         "field": "CPU(s):",
+         "data": "4"
+      },{
+         "field": "On-line CPU(s) list:",
+         "data": "0-3"
+      },{
+         "field": "Vendor ID:",
+         "data": "ARM"
+      },{
+         "field": "Model name:",
+         "data": "Cortex-A72"
+      },{
+         "field": "Model:",
+         "data": "3"
+      },{
+         "field": "Thread(s) per core:",
+         "data": "1"
+      },{
+         "field": "Core(s) per cluster:",
+         "data": "4"
+      },{
+         "field": "Socket(s):",
+         "data": "-"
+      },{
+         "field": "Cluster(s):",
+         "data": "1"
+      },{
+         "field": "Stepping:",
+         "data": "r0p3"
+      },{
+         "field": "CPU(s) scaling MHz:",
+         "data": "33%"
+      },{
+         "field": "CPU max MHz:",
+         "data": "1800.0000"
+      },{
+         "field": "CPU min MHz:",
+         "data": "600.0000"
+      },{
+         "field": "BogoMIPS:",
+         "data": "108.00"
+      },{
+         "field": "Flags:",
+         "data": "fp asimd evtstrm crc32 cpuid"
+      },{
+         "field": "L1d cache:",
+         "data": "128 KiB (4 instances)"
+      },{
+         "field": "L1i cache:",
+         "data": "192 KiB (4 instances)"
+      },{
+         "field": "L2 cache:",
+         "data": "1 MiB (1 instance)"
+      },{
+         "field": "Vulnerability Gather data sampling:",
+         "data": "Not affected"
+      },{
+         "field": "Vulnerability Itlb multihit:",
+         "data": "Not affected"
+      },{
+         "field": "Vulnerability L1tf:",
+         "data": "Not affected"
+      },{
+         "field": "Vulnerability Mds:",
+         "data": "Not affected"
+      },{
+         "field": "Vulnerability Meltdown:",
+         "data": "Not affected"
+      },{
+         "field": "Vulnerability Mmio stale data:",
+         "data": "Not affected"
+      },{
+         "field": "Vulnerability Retbleed:",
+         "data": "Not affected"
+      },{
+         "field": "Vulnerability Spec rstack overflow:",
+         "data": "Not affected"
+      },{
+         "field": "Vulnerability Spec store bypass:",
+         "data": "Vulnerable"
+      },{
+         "field": "Vulnerability Spectre v1:",
+         "data": "Mitigation; __user pointer sanitization"
+      },{
+         "field": "Vulnerability Spectre v2:",
+         "data": "Vulnerable"
+      },{
+         "field": "Vulnerability Srbds:",
+         "data": "Not affected"
+      },{
+         "field": "Vulnerability Tsx async abort:",
+         "data": "Not affected"
+      }
+   ]
+}

--- a/tests/test-hwinfo-data/test-hwinfo.gresource.xml
+++ b/tests/test-hwinfo-data/test-hwinfo.gresource.xml
@@ -15,6 +15,7 @@
     <file>bad-wrong-structure-9.json</file>
     <file>good-no-cpu-max-mhz.json</file>
     <file>good-rockchip.json</file>
+    <file>good-rpi4b.json</file>
     <file>good-xps13.json</file>
   </gresource>
 </gresources>

--- a/tests/test-hwinfo.c
+++ b/tests/test-hwinfo.c
@@ -100,6 +100,7 @@ static const char *NO_CPU_MAX_MHZ_VARIANT =
     ")]";
 
 static const char *ROCKCHIP_VARIANT = "[('Cortex-A12', 4,  1608., 'half thumb fastmult vfp edsp thumbee neon vfpv3 tls vfpv4 idiva idivt vfpd32 lpae evtstrm')]";
+static const char *RPI4B_VARIANT = "[('Cortex-A72', 4, 1800., 'fp asimd evtstrm crc32 cpuid')]";
 static const char *WRONG_DATA_TYPE_VARIANT = "[('hello', 0, 0, 'hi')]";
 static const char *FALLBACK_VARIANT = "[('', 0, 0, '')]";
 
@@ -223,6 +224,7 @@ main (int   argc,
        */
       { "/hwinfo/cpu/good/no-cpu-max-mhz", "good-no-cpu-max-mhz.json", NO_CPU_MAX_MHZ_VARIANT },
       { "/hwinfo/cpu/good/rockchip", "good-rockchip.json", ROCKCHIP_VARIANT },
+      { "/hwinfo/cpu/good/rpi4b", "good-rpi4b.json", RPI4B_VARIANT },
   };
   size_t i;
 

--- a/tests/test-hwinfo.c
+++ b/tests/test-hwinfo.c
@@ -87,19 +87,21 @@ static const char *XPS_13_9343_VARIANT =
     "[("
     "  'Intel(R) Core(TM) i7-5500U CPU @ 2.40GHz',"
     "  4,"
-    "  3000."
+    "  3000.,"
+    "  'fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb invpcid_single pti tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid rdseed adx smap intel_pt xsaveopt ibpb ibrs stibp dtherm ida arat pln pts'"
     ")]";
 
 static const char *NO_CPU_MAX_MHZ_VARIANT =
     "[("
     "  'Intel(R) Core(TM) i7-5500U CPU @ 2.40GHz',"
     "  1,"
-    "  2385.484"
+    "  2385.484,"
+    "  'fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb invpcid_single pti tpr_shadow vnmi flexpriority ept vpid fsgsbase tsc_adjust bmi1 avx2 smep bmi2 erms invpcid rdseed adx smap intel_pt xsaveopt ibpb ibrs stibp dtherm ida arat pln pts'"
     ")]";
 
-static const char *ROCKCHIP_VARIANT = "[('Cortex-A12', 4,  1608.)]";
-static const char *WRONG_DATA_TYPE_VARIANT = "[('hello', 0, 0)]";
-static const char *FALLBACK_VARIANT = "[('', 0, 0)]";
+static const char *ROCKCHIP_VARIANT = "[('Cortex-A12', 4,  1608., 'half thumb fastmult vfp edsp thumbee neon vfpv3 tls vfpv4 idiva idivt vfpd32 lpae evtstrm')]";
+static const char *WRONG_DATA_TYPE_VARIANT = "[('hello', 0, 0, 'hi')]";
+static const char *FALLBACK_VARIANT = "[('', 0, 0, '')]";
 
 typedef struct _CpuTestData {
     const gchar *testpath;
@@ -130,7 +132,7 @@ test_parse_lscpu_json (const CpuTestData *data)
   actual = eins_hwinfo_parse_lscpu_json (json, size);
   g_assert_nonnull (actual);
 
-  expected = g_variant_parse (G_VARIANT_TYPE ("a(sqd)"), data->expected_str,
+  expected = g_variant_parse (G_VARIANT_TYPE ("a(sqds)"), data->expected_str,
                               NULL, NULL, &error);
   g_assert_no_error (error);
 
@@ -147,15 +149,17 @@ assert_cpu_info_for_current_system (GVariant *cpu_payload)
   const gchar *model;
   guint16 n_cpus;
   gdouble max_mhz;
+  const gchar *flags;
 
   g_assert_nonnull (cpu_payload);
-  g_assert_cmpstr (g_variant_get_type_string (cpu_payload), ==, "a(sqd)");
+  g_assert_cmpstr (g_variant_get_type_string (cpu_payload), ==, "a(sqds)");
   g_assert_cmpuint (g_variant_n_children (cpu_payload), >=, 1);
 
-  g_variant_get_child (cpu_payload, 0, "(&sqd)", &model, &n_cpus, &max_mhz);
+  g_variant_get_child (cpu_payload, 0, "(&sqds)", &model, &n_cpus, &max_mhz, &flags);
   g_assert_cmpstr (model, !=, "");
   g_assert_cmpuint (n_cpus, >, 0);
   g_assert_cmpfloat (max_mhz, >=, 0);
+  g_assert_cmpstr (flags, !=, "");
 }
 
 /* Just verify that we can launch lscpu, parse its output, and get something
@@ -178,9 +182,9 @@ test_get_computer_hwinfo (void)
   g_autoptr(GVariant) cpu_payload;
 
   g_assert_nonnull (payload);
-  g_assert_cmpstr (g_variant_get_type_string (payload), ==, "(uuuua(sqd))");
+  g_assert_cmpstr (g_variant_get_type_string (payload), ==, "(uuuua(sqds))");
 
-  g_variant_get (payload, "(uuuu@a(sqd))", &ram_size,
+  g_variant_get (payload, "(uuuu@a(sqds))", &ram_size,
                  &dspace.total, &dspace.used, &dspace.free, &cpu_payload);
 
   assert_ram_size (ram_size);


### PR DESCRIPTION
Since we are making a 5.1.3 release *anyway*, and since there will be an artificial 2-week delay before systems on 5.1.3 automatically upgrade to 6.0.0, I'd like to get this instrumentation change into 5.1.3, so we can start getting information sooner.

- #113 
